### PR TITLE
Add support of building Picolibc based toolchains

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,7 @@
 	path = uclibc-ng
 	url = https://github.com/wbx-github/uclibc-ng.git
 	shallow = true
+[submodule "picolibc"]
+	path = picolibc
+	url = https://github.com/foss-for-synopsys-dwc-arc-processors/picolibc
+	branch = arc-2025.06

--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,7 @@ INSTALL_DIR := @prefix@
 GCC_SRCDIR := @with_gcc_src@
 BINUTILS_SRCDIR := @with_binutils_src@
 NEWLIB_SRCDIR := @with_newlib_src@
+PICOLIBC_SRCDIR := @with_picolibc_src@
 GLIBC_SRCDIR := @with_glibc_src@
 MUSL_SRCDIR := @with_musl_src@
 UCLIBC_SRCDIR := @with_uclibc_src@
@@ -163,11 +164,13 @@ PATH := $(builddir)/install-host-gcc/bin:$(PATH)
 GCC_CHECKING_FLAGS := $(GCC_CHECKING_FLAGS) --enable-werror-always
 endif
 newlib: stamps/build-gcc-newlib-stage2
+picolibc: stamps/build-gcc-picolibc-stage2-nano
 linux: stamps/build-gcc-linux-stage2
 musl: stamps/build-gcc-musl-stage2
 uclibc: stamps/build-gcc-uclibc-stage2
 ifeq (@enable_gdb@,--enable-gdb)
 newlib: stamps/build-gdb-newlib
+picolibc: stamps/build-gdb-picolibc
 linux: stamps/build-gdb-linux
 musl: stamps/build-gdb-musl
 endif
@@ -210,6 +213,9 @@ check-gcc-newlib-nano: stamps/check-gcc-newlib-nano
 .PHONY: check-libc-newlib check-libc-newlib-nano
 check-libc-newlib: stamps/check-libc-newlib
 check-libc-newlib-nano: stamps/check-libc-newlib-nano
+.PHONY: check-libc-picolibc-perf check-libc-picolibc-nano
+check-libc-picolibc-perf: stamps/check-libc-picolibc-perf
+check-libc-picolibc-nano: stamps/check-libc-picolibc-nano
 .PHONY: check-glibc-linux
 check-glibc-linux: $(addprefix stamps/check-glibc-linux-,$(GLIBC_MULTILIB_NAMES))
 .PHONY: check-dhrystone check-dhrystone-linux check-dhrystone-newlib
@@ -341,6 +347,12 @@ else
 NEWLIB_SRC_GIT :=
 endif
 
+ifeq ($(findstring $(srcdir),$(PICOLIBC_SRCDIR)),$(srcdir))
+PICOLIBC_SRC_GIT := $(PICOLIBC_SRCDIR)/.git
+else
+PICOLIBC_SRC_GIT :=
+endif
+
 ifeq ($(findstring $(srcdir),$(GLIBC_SRCDIR)),$(srcdir))
 GLIBC_SRC_GIT := $(GLIBC_SRCDIR)/.git
 else
@@ -390,7 +402,7 @@ else
 GCCPKGVER :=
 endif
 
-TARGET_DIRS := binutils gdb gcc newlib dejagnu
+TARGET_DIRS := binutils gdb gcc newlib dejagnu picolibc
 $(srcdir)/%/.git:
 	cd $(srcdir) && \
 	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
@@ -846,6 +858,309 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
+
+#
+# Picolibc
+#
+
+stamps/build-binutils-picolibc: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATION_STAMP)
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+# CC_FOR_TARGET is required for the ld testsuite.
+	cd $(notdir $@) && CC_FOR_TARGET=$(NEWLIB_CC_FOR_TARGET) $</configure \
+		--target=$(NEWLIB_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR) \
+		--enable-plugins \
+		@with_guile@ \
+		--disable-werror \
+		$(BINUTILS_TARGET_FLAGS) \
+		--disable-gdb \
+		--disable-sim \
+		--disable-libdecnumber \
+		--disable-readline \
+		$(WITH_ISA_SPEC) \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)"
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gdb-picolibc: $(GDB_SRCDIR) $(GDB_SRC_GIT) $(PREPARATION_STAMP)
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+# CC_FOR_TARGET is required for the ld testsuite.
+	cd $(notdir $@) && CC_FOR_TARGET=$(NEWLIB_CC_FOR_TARGET) $</configure \
+		--target=$(NEWLIB_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR) \
+		@with_guile@ \
+		--disable-werror \
+		$(GDB_TARGET_FLAGS) \
+		--enable-gdb \
+		--disable-gas \
+		--disable-binutils \
+		--disable-ld \
+		--disable-gold \
+		--disable-gprof \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)"
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gcc-picolibc-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils-picolibc
+	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--target=$(NEWLIB_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR) \
+		--disable-shared \
+		--disable-threads \
+		--enable-tls \
+		--enable-languages=c,c++ \
+		@with_system_zlib@ \
+		--with-newlib \
+		--without-headers \
+		--disable-libmudflap \
+		--disable-libssp \
+		--disable-libquadmath \
+		--disable-libgomp \
+		--disable-nls \
+		--disable-tm-clone-registry \
+		--src=$(gccsrcdir) \
+		$(GCC_CHECKING_FLAGS) \
+		$(GCC_MULTILIB_FLAGS) \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
+		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
+		$(GCC_EXTRA_CONFIGURE_FLAGS) \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)" \
+		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
+	$(MAKE) -C $(notdir $@) all-gcc
+	$(MAKE) -C $(notdir $@) install-gcc
+	mkdir -p $(dir $@) && touch $@
+
+PICOLIBC_COMMON_CONFIGURE_OPTIONS := \
+	--cross-file cross-$(NEWLIB_TUPLE).txt \
+	-Dincludedir=include \
+	-Dsystem-libc=true \
+	-Dposix-console=true \
+	-Dlite-exit=true \
+	-Dnewlib-obsolete-math=false \
+	-Dwant-math-errno=true \
+	-Datomic-signal=false \
+	-Dassert-verbose=true \
+	-Ddebug=true \
+	-Dwerror=true
+
+PICOLIBC_PERF_CONFIGURE_OPTIONS := \
+	-Doptimization=3 \
+	-Dio-c99-formats=true \
+	-Dio-long-long=true \
+	-Dio-long-double=true \
+	-Dio-percent-b=true \
+	-Dprintf-percent-n=true \
+	-Dfast-bufio=true \
+	-Dmb-capable=true \
+	-Dio-wchar=true \
+	$(PICOLIBC_COMMON_CONFIGURE_OPTIONS)
+
+PICOLIBC_NANO_CONFIGURE_OPTIONS := \
+	-Doptimization=s \
+	-Dio-c99-formats=true \
+	-Dio-long-long=false \
+	-Dio-long-double=false \
+	-Dio-percent-b=false \
+	-Dprintf-percent-n=false \
+	-Dfast-bufio=false \
+	-Dmb-capable=false \
+	-Dio-wchar=false \
+	$(PICOLIBC_COMMON_CONFIGURE_OPTIONS)
+
+define PICOLIBC_OBSOLETE_MATH_BLOCK
+#if (__riscv_flen < 64) && !defined(__riscv_zdinx)
+#undef __OBSOLETE_MATH
+#undef __OBSOLETE_MATH_FLOAT
+#undef __OBSOLETE_MATH_DOUBLE
+#define __OBSOLETE_MATH 1
+#endif
+endef
+export PICOLIBC_OBSOLETE_MATH_BLOCK
+
+stamps/configure-picolibc-perf: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/build-gcc-picolibc-stage1
+	rm -rf $@ stamps/build-picolibc-perf build-picolibc-perf
+	mkdir build-picolibc-perf
+	cd build-picolibc-perf && $(srcdir)/scripts/generate_picolibc_cross_file \
+		--triplet $(NEWLIB_TUPLE) \
+		--cflags "$(CFLAGS_FOR_TARGET)" \
+		> cross-$(NEWLIB_TUPLE).txt
+	cd build-picolibc-perf && meson setup . $(PICOLIBC_SRCDIR) \
+		-Dprefix=$(INSTALL_DIR)/$(NEWLIB_TUPLE) \
+		-Dlibdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		-Dspecsdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		$(PICOLIBC_PERF_CONFIGURE_OPTIONS)
+	cd build-picolibc-perf && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-picolibc-perf: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/configure-picolibc-perf
+	ninja -C $(notdir $@)
+	ninja -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gcc-picolibc-stage2: ENABLED_LANGUAGES?="c,c++"
+stamps/build-gcc-picolibc-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-picolibc-perf
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--target=$(NEWLIB_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR) \
+		--disable-shared \
+		--disable-threads \
+		--enable-languages=$(ENABLED_LANGUAGES) \
+		--with-pkgversion="$(GCCPKGVER)" \
+		@with_system_zlib@ \
+		--enable-tls \
+		--with-newlib \
+		--with-headers=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/include \
+		--disable-libmudflap \
+		--disable-libssp \
+		--disable-libquadmath \
+		--disable-libgomp \
+		--disable-nls \
+		--disable-tm-clone-registry \
+		--src=$(gccsrcdir) \
+		$(GCC_CHECKING_FLAGS) \
+		$(GCC_MULTILIB_FLAGS) \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
+		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
+		$(GCC_EXTRA_CONFIGURE_FLAGS) \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)" \
+		CFLAGS_FOR_TARGET="-O3 -g $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-O3 -g $(CXXFLAGS_FOR_TARGET)"
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/configure-picolibc-nano: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/build-gcc-picolibc-stage2
+	rm -rf $@ stamps/build-picolibc-nano build-picolibc-nano
+	mkdir build-picolibc-nano
+	cd build-picolibc-nano && $(srcdir)/scripts/generate_picolibc_cross_file \
+		--triplet $(NEWLIB_TUPLE) \
+		--cflags "$(CFLAGS_FOR_TARGET) -msave-restore" \
+		> cross-$(NEWLIB_TUPLE).txt
+	cd build-picolibc-nano && meson setup . $(PICOLIBC_SRCDIR) \
+		-Dprefix=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE) \
+		-Dlibdir=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE)/lib \
+		-Dspecsdir=none \
+		$(PICOLIBC_NANO_CONFIGURE_OPTIONS)
+	cd build-picolibc-nano && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-picolibc-nano: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/configure-picolibc-nano
+	ninja -C $(notdir $@)
+	ninja -C $(notdir $@) install
+	$(srcdir)/scripts/generate_picolibc_nano_specs \
+		--triplet $(NEWLIB_TUPLE) \
+		--nano-dir-name picolibc-nano \
+		> $(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/nano.specs
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gcc-picolibc-stage2-nano: ENABLED_LANGUAGES?="c,c++"
+stamps/build-gcc-picolibc-stage2-nano: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-picolibc-nano
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--target=$(NEWLIB_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR)/picolibc-nano \
+		--disable-shared \
+		--disable-threads \
+		--enable-languages=$(ENABLED_LANGUAGES) \
+		--with-pkgversion="$(GCCPKGVER)" \
+		@with_system_zlib@ \
+		--enable-tls \
+		--with-newlib \
+		--with-headers=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE)/include \
+		--disable-libmudflap \
+		--disable-libssp \
+		--disable-libquadmath \
+		--disable-libgomp \
+		--disable-nls \
+		--disable-tm-clone-registry \
+		--src=$(gccsrcdir) \
+		--enable-target-optspace \
+		$(GCC_CHECKING_FLAGS) \
+		$(GCC_MULTILIB_FLAGS) \
+		$(WITH_ABI) \
+		$(WITH_ARCH) \
+		$(WITH_TUNE) \
+		$(WITH_ISA_SPEC) \
+		$(GCC_EXTRA_CONFIGURE_FLAGS) \
+		CFLAGS_FOR_TARGET="-g $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-g $(CXXFLAGS_FOR_TARGET)"
+	$(MAKE) -C $(notdir $@) all-target-libgcc all-target-libstdc++-v3
+	$(MAKE) -C $(notdir $@) install-target-libgcc install-target-libstdc++-v3
+	mkdir -p $(dir $@) && touch $@
+
+stamps/configure-picolibc-perf-test: stamps/build-gcc-picolibc-stage2 $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT)
+	rm -rf $@ stamps/build-picolibc-perf-test build-picolibc-perf-test
+	mkdir build-picolibc-perf-test
+	cd build-picolibc-perf-test && $(srcdir)/scripts/generate_picolibc_cross_file \
+		--triplet $(NEWLIB_TUPLE) \
+		--cflags "$(CFLAGS_FOR_TARGET)" \
+		--simulator "$(SIM)" \
+		> cross-$(NEWLIB_TUPLE).txt
+	cd build-picolibc-perf-test && meson setup . $(PICOLIBC_SRCDIR) \
+		-Dprefix=$(INSTALL_DIR)/$(NEWLIB_TUPLE) \
+		-Dlibdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		-Dspecsdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		-Dtests=true \
+		$(PICOLIBC_PERF_CONFIGURE_OPTIONS)
+	cd build-picolibc-perf-test && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-picolibc-perf-test: stamps/configure-picolibc-perf-test
+	ninja -C $(notdir $@)
+	mkdir -p $(dir $@) && touch $@
+
+stamps/check-libc-picolibc-perf: stamps/build-picolibc-perf-test $(SIM_STAMP)
+	ninja -C build-picolibc-perf-test test
+	date > $@
+
+stamps/configure-picolibc-nano-test: stamps/build-gcc-picolibc-stage2 $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT)
+	rm -rf $@ stamps/build-picolibc-nano-test build-picolibc-nano-test
+	mkdir build-picolibc-nano-test
+	cd build-picolibc-nano-test && $(srcdir)/scripts/generate_picolibc_cross_file \
+		--triplet $(NEWLIB_TUPLE) \
+		--cflags "$(CFLAGS_FOR_TARGET)" \
+		--simulator "$(SIM)" \
+		> cross-$(NEWLIB_TUPLE).txt
+	cd build-picolibc-nano-test && meson setup . $(PICOLIBC_SRCDIR) \
+		-Dprefix=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE) \
+		-Dlibdir=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE)/lib \
+		-Dspecsdir=none \
+		-Dtests=true \
+		$(PICOLIBC_NANO_CONFIGURE_OPTIONS)
+	cd build-picolibc-nano-test && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-picolibc-nano-test: stamps/configure-picolibc-nano-test
+	ninja -C $(notdir $@)
+	mkdir -p $(dir $@) && touch $@
+
+stamps/check-libc-picolibc-nano: stamps/build-picolibc-nano-test $(SIM_STAMP)
+	ninja -C build-picolibc-nano-test test
+	date > $@
 
 #
 # MUSL

--- a/Makefile.in
+++ b/Makefile.in
@@ -16,6 +16,7 @@ PK_SRCDIR := @with_pk_src@
 LLVM_SRCDIR := @with_llvm_src@
 DEJAGNU_SRCDIR := @with_dejagnu_src@
 DEBUG_INFO := @debug_info@
+HOST_DEBUG_INFO := @host_debug_info@
 ENABLE_DEFAULT_PIE := @enable_default_pie@
 DEJAGNU_SRCDIR := @with_dejagnu_src@
 
@@ -108,6 +109,8 @@ else
 CMODEL_FOR_TARGET := @cmodel@
 endif
 
+CFLAGS_FOR_HOST := $(CFLAGS_FOR_HOST_EXTRA) $(HOST_DEBUG_INFO) @host_cflags@
+CXXFLAGS_FOR_HOST := $(CXXFLAGS_FOR_HOST_EXTRA) $(HOST_DEBUG_INFO) @host_cxxflags@
 CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cflags@ $(CMODEL_FOR_TARGET)
 CXXFLAGS_FOR_TARGET := $(CXXFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cxxflags@ $(CMODEL_FOR_TARGET)
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) $(CMODEL_FOR_TARGET)
@@ -661,7 +664,9 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATI
 		--disable-sim \
 		--disable-libdecnumber \
 		--disable-readline \
-		$(WITH_ISA_SPEC)
+		$(WITH_ISA_SPEC) \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -682,7 +687,9 @@ stamps/build-gdb-newlib: $(GDB_SRCDIR) $(GDB_SRC_GIT) $(PREPARATION_STAMP)
 		--disable-binutils \
 		--disable-ld \
 		--disable-gold \
-		--disable-gprof
+		--disable-gprof \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -716,6 +723,8 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binuti
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)" \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@) all-gcc
@@ -830,6 +839,8 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
+		CFLAGS="$(CFLAGS_FOR_HOST)" \
+		CXXFLAGS="$(CXXFLAGS_FOR_HOST)" \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)

--- a/configure
+++ b/configure
@@ -627,6 +627,7 @@ with_gdb_src
 with_uclibc_src
 with_musl_src
 with_glibc_src
+with_picolibc_src
 with_newlib_src
 with_binutils_src
 with_gcc_src
@@ -720,6 +721,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_linux
+enable_picolibc
 enable_debug_info
 enable_host_debug_info
 enable_default_pie
@@ -749,6 +751,7 @@ enable_host_gcc
 with_gcc_src
 with_binutils_src
 with_newlib_src
+with_picolibc_src
 with_glibc_src
 with_musl_src
 with_uclibc_src
@@ -1390,6 +1393,8 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-linux          set linux as the default make target
                           [--disable-linux]
+  --enable-picolibc       set Picolibc as the default make target
+                          [--disable-picolibc]
   --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
                           information
   --enable-host-debug-info
@@ -1452,6 +1457,8 @@ Optional Packages:
   --with-binutils-src     Set binutils source path, use builtin source by
                           default
   --with-newlib-src       Set newlib source path, use builtin source by
+                          default
+  --with-picolibc-src     Set picolibc source path, use builtin source by
                           default
   --with-glibc-src        Set glibc source path, use builtin source by default
   --with-musl-src         Set musl source path, use builtin source by default
@@ -3950,9 +3957,23 @@ else $as_nop
 fi
 
 
+# Check whether --enable-picolibc was given.
+if test ${enable_picolibc+y}
+then :
+  enableval=$enable_picolibc;
+else $as_nop
+  enable_picolibc=no
+
+fi
+
+
 if test "x$enable_linux" != xno
 then :
   default_target=linux
+
+elif test "x$enable_picolibc" != xno
+then :
+  default_target=picolibc
 
 else $as_nop
   default_target=newlib
@@ -4492,6 +4513,27 @@ then :
 
 else $as_nop
   with_newlib_src="\$(srcdir)/newlib"
+
+fi
+
+	}
+{
+
+# Check whether --with-picolibc-src was given.
+if test ${with_picolibc_src+y}
+then :
+  withval=$with_picolibc_src;
+else $as_nop
+  with_picolibc_src=default
+
+fi
+
+	  if test "x$with_picolibc_src" != xdefault
+then :
+  with_picolibc_src=$with_picolibc_src
+
+else $as_nop
+  with_picolibc_src="\$(srcdir)/picolibc"
 
 fi
 

--- a/configure
+++ b/configure
@@ -1421,7 +1421,7 @@ Optional Packages:
                           Sets the vendor part of the triplet alias
   --with-arch=rv64gc      Sets the base RISC-V ISA, defaults to rv64gc
   --with-abi=lp64d        Sets the base RISC-V ABI, defaults to lp64d
-  --with-tune=rocket      Set the base RISC-V CPU, defaults to rocket
+  --with-tune=default     Set the base RISC-V CPU, defaults to rocket
   --with-isa-spec=20191213
                           Set the default ISA spec version, default to
                           20191213, available options: 2.2, 20190608, 20191213
@@ -4103,7 +4103,7 @@ if test ${with_tune+y}
 then :
   withval=$with_tune;
 else $as_nop
-  with_tune=rocket
+  with_tune=default
 
 fi
 

--- a/configure
+++ b/configure
@@ -636,6 +636,8 @@ enable_gdb
 with_guile
 with_system_zlib
 configure_host
+host_cxxflags
+host_cflags
 target_cxxflags
 target_cflags
 cmodel
@@ -652,9 +654,10 @@ WITH_ISA_SPEC
 WITH_TUNE
 WITH_ABI
 WITH_ARCH
-enable_default_pie
 vendor_alias
 vendor
+enable_default_pie
+host_debug_info
 debug_info
 default_target
 FETCHER
@@ -718,6 +721,7 @@ ac_user_opts='
 enable_option_checking
 enable_linux
 enable_debug_info
+enable_host_debug_info
 enable_default_pie
 with_vendor
 with_vendor_alias
@@ -734,6 +738,8 @@ enable_gcc_checking
 with_cmodel
 with_target_cflags
 with_target_cxxflags
+with_host_cflags
+with_host_cxxflags
 with_host
 with_system_zlib
 with_guile
@@ -1386,6 +1392,9 @@ Optional Features:
                           [--disable-linux]
   --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
                           information
+  --enable-host-debug-info
+                          build host Binutils, GDB and GCC with debug
+                          information
   --enable-default-pie    build linux toolchain with default PIE
                           [--enable-default-pie]
   --enable-multilib       build both RV32 and RV64 runtime libraries
@@ -1402,10 +1411,10 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-arch=rv64gc      Sets the base RISC-V ISA, defaults to rv64gc
   --with-vendor=unknown   Sets the vendor part of the triplet
   --with-vendor-alias=unknown
                           Sets the vendor part of the triplet alias
+  --with-arch=rv64gc      Sets the base RISC-V ISA, defaults to rv64gc
   --with-abi=lp64d        Sets the base RISC-V ABI, defaults to lp64d
   --with-tune=rocket      Set the base RISC-V CPU, defaults to rocket
   --with-isa-spec=20191213
@@ -1431,6 +1440,9 @@ Optional Packages:
                           libgcc [--with-cmodel=medlow]
   --with-target-cflags    Add extra target flags for C for library code
   --with-target-cxxflags  Add extra target flags for C++ for library code
+  --with-host-cflags      Add extra flags for C for host Binutils, GDB and GCC
+  --with-host-cxxflags    Add extra flags for C++ for host Binutils, GDB and
+                          GCC
   --with-host=x86_64-w64-mingw32
                           Sets the host for the tools, you probably want
                           nothing
@@ -3974,6 +3986,33 @@ else $as_nop
 
 fi
 
+# Check whether --enable-host_debug_info was given.
+if test ${enable_host_debug_info+y}
+then :
+  enableval=$enable_host_debug_info; enable_host_debug_info=yes
+else $as_nop
+  enable_host_debug_info=no
+
+fi
+
+
+if test "x$enable_host_debug_info" != xyes
+then :
+  disable_host_debug_info=yes
+else $as_nop
+  disable_host_debug_info=no
+
+fi
+
+if test "x$enable_host_debug_info" != xyes
+then :
+  host_debug_info=""
+
+else $as_nop
+  host_debug_info="-g"
+
+fi
+
 # Check whether --enable-default-pie was given.
 if test ${enable_default_pie+y}
 then :
@@ -3994,11 +4033,11 @@ else $as_nop
 fi
 
 
-
 # Check whether --with-vendor was given.
-if test "${with_vendor+set}" = set; then :
+if test ${with_vendor+y}
+then :
   withval=$with_vendor;
-else
+else $as_nop
   with_vendor=unknown
 
 fi
@@ -4006,9 +4045,10 @@ fi
 
 
 # Check whether --with-vendor_alias was given.
-if test "${with_vendor_alias+set}" = set; then :
+if test ${with_vendor_alias+y}
+then :
   withval=$with_vendor_alias;
-else
+else $as_nop
   with_vendor_alias=unknown
 
 fi
@@ -4252,6 +4292,25 @@ then :
 fi
 
 target_cxxflags=$with_target_cxxflags
+
+
+
+# Check whether --with-host_cflags was given.
+if test ${with_host_cflags+y}
+then :
+  withval=$with_host_cflags;
+fi
+
+host_cflags=$with_host_cflags
+
+
+# Check whether --with-host_cxxflags was given.
+if test ${with_host_cxxflags+y}
+then :
+  withval=$with_host_cxxflags;
+fi
+
+host_cxxflags=$with_host_cxxflags
 
 
 ac_config_files="$ac_config_files Makefile"

--- a/configure.ac
+++ b/configure.ac
@@ -47,8 +47,15 @@ AC_ARG_ENABLE(linux,
         [enable_linux=no]
         )
 
-AS_IF([test "x$enable_linux" != xno],
-	[AC_SUBST(default_target, linux)],
+AC_ARG_ENABLE(picolibc,
+        [AS_HELP_STRING([--enable-picolibc],
+		[set Picolibc as the default make target @<:@--disable-picolibc@:>@])],
+        [],
+        [enable_picolibc=no]
+        )
+
+AS_IF([test "x$enable_linux" != xno], [AC_SUBST(default_target, linux)],
+	[test "x$enable_picolibc" != xno], [AC_SUBST(default_target, picolibc)],
 	[AC_SUBST(default_target, newlib)])
 
 AC_ARG_ENABLE(debug_info,
@@ -349,6 +356,7 @@ AC_DEFUN([AX_ARG_WITH_SRC],
 AX_ARG_WITH_SRC(gcc, gcc)
 AX_ARG_WITH_SRC(binutils, binutils)
 AX_ARG_WITH_SRC(newlib, newlib)
+AX_ARG_WITH_SRC(picolibc, picolibc)
 AX_ARG_WITH_SRC(glibc, glibc)
 AX_ARG_WITH_SRC(musl, musl)
 AX_ARG_WITH_SRC(uclibc, uclibc-ng)

--- a/configure.ac
+++ b/configure.ac
@@ -130,10 +130,10 @@ AC_ARG_WITH(abi,
 	)
 
 AC_ARG_WITH(tune,
-	[AS_HELP_STRING([--with-tune=rocket],
+	[AS_HELP_STRING([--with-tune=default],
 		[Set the base RISC-V CPU, defaults to rocket])],
 	[],
-	[with_tune=rocket]
+	[with_tune=default]
 	)
 
 AC_ARG_WITH(isa-spec,

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,22 @@ AS_IF([test "x$enable_debug_info" != xyes],
 	[AC_SUBST(debug_info, "")],
 	[AC_SUBST(debug_info, "-g")])
 
+AC_ARG_ENABLE(host_debug_info,
+        [AS_HELP_STRING([--enable-host-debug-info],
+		[build host Binutils, GDB and GCC with debug information])],
+        [enable_host_debug_info=yes],
+        [enable_host_debug_info=no]
+        )
+
+AS_IF([test "x$enable_host_debug_info" != xyes],
+        [disable_host_debug_info=yes],
+        [disable_host_debug_info=no]
+        )
+
+AS_IF([test "x$enable_host_debug_info" != xyes],
+	[AC_SUBST(host_debug_info, "")],
+	[AC_SUBST(host_debug_info, "-g")])
+
 AC_ARG_ENABLE(default-pie,
         [AS_HELP_STRING([--enable-default-pie],
 		[build linux toolchain with default PIE @<:@--enable-default-pie@:>@])],
@@ -233,6 +249,21 @@ AC_ARG_WITH(target_cxxflags,
 	[]
 	)
 AC_SUBST(target_cxxflags, $with_target_cxxflags)
+
+AC_ARG_WITH(host_cflags,
+	[AS_HELP_STRING([--with-host-cflags],
+		[Add extra flags for C for host Binutils, GDB and GCC])],
+	[],
+	[]
+	)
+AC_SUBST(host_cflags, $with_host_cflags)
+AC_ARG_WITH(host_cxxflags,
+	[AS_HELP_STRING([--with-host-cxxflags],
+		[Add extra flags for C++ for host Binutils, GDB and GCC])],
+	[],
+	[]
+	)
+AC_SUBST(host_cxxflags, $with_host_cxxflags)
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([scripts/wrapper/awk/awk], [chmod +x scripts/wrapper/awk/awk])

--- a/scripts/generate_picolibc_cross_file
+++ b/scripts/generate_picolibc_cross_file
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+DEFAULT_TRIPLET = "riscv64-unknown-elf"
+DEFAULT_CFLAGS = "-O2"
+DEFAULT_FLASH_ADDR = "0x80000000"
+DEFAULT_FLASH_SIZE = "0x00200000"
+DEFAULT_RAM_ADDR = "0x80200000"
+DEFAULT_RAM_SIZE = "0x00200000"
+
+
+def parse_options(argv):
+    parser = argparse.ArgumentParser(
+        description="This tool generates a cross toolchain file for Meson build system for "
+        "Picolibc standard library."
+    )
+    parser.add_argument(
+        "--triplet",
+        type=str,
+        default=DEFAULT_TRIPLET,
+        help="A target triplet, default: {}".format(DEFAULT_TRIPLET),
+    )
+    parser.add_argument(
+        "--cflags",
+        type=str,
+        default=DEFAULT_CFLAGS,
+        help="CFLAGS for libraries and tests, default: {}".format(DEFAULT_CFLAGS),
+    )
+    parser.add_argument(
+        "--simulator",
+        type=str,
+        choices=("qemu", "nsim"),
+        default="qemu",
+        help="A simulator for testing, default: qemu",
+    )
+    parser.add_argument("--flash-addr", type=str, default=DEFAULT_FLASH_ADDR)
+    parser.add_argument("--flash-size", type=str, default=DEFAULT_FLASH_SIZE)
+    parser.add_argument("--ram-addr", type=str, default=DEFAULT_RAM_ADDR)
+    parser.add_argument("--ram-size", type=str, default=DEFAULT_RAM_SIZE)
+    return parser.parse_args()
+
+
+def main(argv):
+    options = parse_options(argv)
+    triplet = options.triplet
+
+    if not triplet:
+        print("The --triplet cannot be empty or null.", file=sys.stderr)
+        return 1
+
+    if len(triplet.split("-")) < 3:
+        print(
+            'The --triplet must contain at least 3 words separated by "-".',
+            file=sys.stderr,
+        )
+        return 1
+
+    family, vendor = triplet.split("-")[:2]
+
+    # Generate [binaries] section
+    content = "[binaries]\n"
+    content += "c = '{}-gcc'\n".format(options.triplet)
+    content += "cpp = '{}-g++'\n".format(options.triplet)
+    content += "ar = '{}-ar'\n".format(options.triplet)
+    content += "as = '{}-as'\n".format(options.triplet)
+    content += "strip = '{}-strip'\n".format(options.triplet)
+    content += "nm = '{}-nm'\n".format(options.triplet)
+
+    if options.simulator == "qemu":
+        content += (
+            r"""exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-riscv "$@"', 'run-riscv']"""
+            + "\n"
+        )
+    else:
+        print("This simulator is not supported yet: {}.".format(options.simulator), file=sys.stderr)
+        return 1
+
+    # Generate [host_machine] section
+    content += "\n[host_machine]\n"
+    content += "system = '{}'\n".format(vendor)
+    content += "cpu_family = '{}'\n".format(family)
+    content += "cpu = 'riscv'\n"
+    content += "endian = 'little'\n"
+
+    # Generate [built-in options] section
+    content += "\n[built-in options]\n"
+    c_args = [
+        "-nostdlib",
+        "-ffunction-sections",
+        "-fdata-sections",
+        "-fno-common",
+        "-ftls-model=local-exec",
+    ]
+
+    if options.cflags:
+        c_args.extend(options.cflags.split())
+
+    content += "c_args = {}\n".format(repr(c_args))
+    content += "cpp_args = {}\n".format(repr(c_args))
+    content += "c_link_args = []\n"
+    content += "cpp_link_args = []\n"
+
+    # Generate [properties] section
+    content += "\n[properties]\n"
+    content += "needs_exe_wrapper = true\n"
+    content += "skip_sanity_check = true\n"
+    content += "default_flash_addr = '{}'\n".format(options.flash_addr)
+    content += "default_flash_size = '{}'\n".format(options.flash_size)
+    content += "default_ram_addr = '{}'\n".format(options.ram_addr)
+    content += "default_ram_size = '{}'\n".format(options.ram_size)
+
+    print(content)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/generate_picolibc_nano_specs
+++ b/scripts/generate_picolibc_nano_specs
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+DEFAULT_TRIPLET = "riscv64-unknown-elf"
+DEFAULT_NANO_DIR_NAME = "picolibc-nano"
+
+
+def parse_options(argv):
+    parser = argparse.ArgumentParser(
+        description="This tool generates nano.specs file for Meson build system for "
+        "Picolibc standard library."
+    )
+    parser.add_argument(
+        "--triplet",
+        type=str,
+        default=DEFAULT_TRIPLET,
+        help="A target triplet, default: {}".format(DEFAULT_TRIPLET),
+    )
+    parser.add_argument(
+        "--nano-dir-name",
+        type=str,
+        default=DEFAULT_NANO_DIR_NAME,
+        help="A name of Picolibc installation directory for nano configuration, default: {}".format(
+            DEFAULT_NANO_DIR_NAME
+        ),
+    )
+    return parser.parse_args()
+
+
+def main(argv):
+    options = parse_options(argv)
+    triplet = options.triplet
+    dirname = options.nano_dir_name
+
+    if not triplet:
+        print("The --triplet cannot be empty or null.", file=sys.stderr)
+        return 1
+
+    if not dirname:
+        print("The --nano-dir-name cannot be empty or null.", file=sys.stderr)
+        return 1
+
+    content  = "%rename link    picolibc_nano_link\n"
+    content += "%rename cpp     picolibc_nano_cpp\n"
+    content += "%rename cc1plus picolibc_nano_cc1plus\n\n"
+    content += "*cpp:\n"
+    content += "-isystem %:getenv(GCC_EXEC_PREFIX ../../{}/{}/include) %(picolibc_nano_cpp)\n\n".format(dirname, triplet)
+    content += "*cc1plus:\n"
+    content += "-idirafter %:getenv(GCC_EXEC_PREFIX ../../{}/{}/include) %(picolibc_nano_cc1plus)\n\n".format(dirname, triplet)
+    content += "*link:\n"
+    content += "-L%:getenv(GCC_EXEC_PREFIX ../../{0}/{1}/lib/%M) -L%:getenv(GCC_EXEC_PREFIX ../../{0}/{1}/lib) %(picolibc_nano_link)\n".format(dirname, triplet)
+
+    print(content)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
# Add support of building Picolibc based toolchains

Use this option to use Picolibc for building a baremetal toolchain:

    --enable-picolibc

Here is a sample command line for configuring and building a Picolibc toolchain for ARC-V:

    ./configure \
        --prefix=<path> \
        --with-arch=rv32imafc \
        --with-tune=rocket \
        --with-abi=ilp32f \
        --with-cmodel=medlow \
        --with-triplet-xlen=64 \
        --with-sim=qemu \
        --enable-picolibc \
        --enable-gdb \
        --enable-multilib \
        --enable-qemu-system \
        --with-vendor=snps \
        --with-vendor-alias=unknown \
        --with-multilib-generator="" \
        --enable-debug-info \
        --with-host-cflags="-O2" \
        --with-host-cxxflags="-O2"
    make
    make aliases

Note that building Picolibc requires Meson and Ninja on a host system.

Two versions of Picolibc, libgcc and libstdc++ are built:

1. -O3 optimized libraries for default linking.
2. -Os optimized libraries in a separate picolibc-nano
   directory.

Use -specs=nano.specs to link a program with size optimized libraries.

Also, stamps/check-libc-picolibc target builds Picolibc for running tests and runs them. Only QEMU is supported so far.

# Additional features

## Add support of --with-triplet-xlen=N option 

This option sets XLEN part of a triplet. For example, it allows using riscv64-unknown-elf triplet when rv32* is a default march value.

## Add --enable-host-debug-info, --with-host-cflags and --with-host-cxxflags options

1. --enable-host-debug-info builds host tools (Binutils, GDB and GCC) with debug symbols.
2. --with-host-cflags and --with-host-cxxflags adds extra CFLAGS/CXXFLAGS for building host tools (Binutils, GDB and GCC). Maybe useful for debugging host tools.

Note that these options affect only baremetal toolchains and they have not been tested for Linux host and native toolchains.