### PR TITLE
nsim: Add riscv{32,64}-elf-run symlinks wrappers.

### DIFF
--- a/scripts/wrapper/nsim/riscv32-elf-run
+++ b/scripts/wrapper/nsim/riscv32-elf-run
@@ -1,0 +1,1 @@
+riscv32-unknown-elf-run

--- a/scripts/wrapper/nsim/riscv64-elf-run
+++ b/scripts/wrapper/nsim/riscv64-elf-run
@@ -1,0 +1,1 @@
+riscv32-unknown-elf-run


### PR DESCRIPTION
Create symlinks riscv32-elf-run and riscv64-elf-run pointing to riscv32-unknown-elf-run to be used by Jenkins.