### PR TITLE
Apply debug information toggle to GCC, Binutils and GDB.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -662,8 +662,8 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATI
 		--disable-libdecnumber \
 		--disable-readline \
 		$(WITH_ISA_SPEC) \
-		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
-		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)"
+		CFLAGS="-O2 $(CFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS="-O2 $(CXXFLAGS) $(DEBUG_INFO)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -685,8 +685,8 @@ stamps/build-gdb-newlib: $(GDB_SRCDIR) $(GDB_SRC_GIT) $(PREPARATION_STAMP)
 		--disable-ld \
 		--disable-gold \
 		--disable-gprof \
-		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
-		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)"
+		CFLAGS="-O2 $(CFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS="-O2 $(CXXFLAGS) $(DEBUG_INFO)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -720,10 +720,10 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binuti
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
-		CFLAGS="$(CFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS)" \
-		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
-		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
+		CFLAGS="-O2 $(CFLAGS)" \
+		CXXFLAGS="-O2 $(CXXFLAGS)" \
+		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@) all-gcc
 	$(MAKE) -C $(notdir $@) install-gcc
 	mkdir -p $(dir $@) && touch $@
@@ -836,10 +836,10 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
-		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
-		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)" \
-		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
-		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
+		CFLAGS="-O2 $(CFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS="-O2 $(CXXFLAGS) $(DEBUG_INFO)" \
+		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@

--- a/Makefile.in
+++ b/Makefile.in
@@ -662,8 +662,8 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) $(PREPARATI
 		--disable-libdecnumber \
 		--disable-readline \
 		$(WITH_ISA_SPEC) \
-		CFLAGS="-O0 -g" \
-		CXXFLAGS="-O0 -g"
+		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -685,8 +685,8 @@ stamps/build-gdb-newlib: $(GDB_SRCDIR) $(GDB_SRC_GIT) $(PREPARATION_STAMP)
 		--disable-ld \
 		--disable-gold \
 		--disable-gprof \
-		CFLAGS="-O0 -g" \
-		CXXFLAGS="-O0 -g"
+		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -720,8 +720,8 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binuti
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
-		CFLAGS="-O0 -g" \
-		CXXFLAGS="-O0 -g" \
+		CFLAGS="$(CFLAGS)" \
+		CXXFLAGS="$(CXXFLAGS)" \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@) all-gcc
@@ -836,8 +836,8 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
-		CFLAGS="-O0 -g" \
-		CXXFLAGS="-O0 -g" \
+		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)" \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)

--- a/configure
+++ b/configure
@@ -1384,7 +1384,7 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-linux          set linux as the default make target
                           [--disable-linux]
-  --enable-debug-info     build glibc/musl/newlibc/libgcc with debug
+  --enable-debug-info     build gcc/binutils/glibc/musl/newlibc/libgcc with debug
                           information
   --enable-default-pie    build linux toolchain with default PIE
                           [--enable-default-pie]
@@ -3970,7 +3970,7 @@ then :
   debug_info=""
 
 else $as_nop
-  debug_info="-g"
+  debug_info="-g3 -O0 -fvar-tracking-assignments"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AS_IF([test "x$enable_linux" != xno],
 
 AC_ARG_ENABLE(debug_info,
         [AS_HELP_STRING([--enable-debug-info],
-		[build glibc/musl/newlibc/libgcc with debug information])],
+		[build gcc/binutils/glibc/musl/newlibc/libgcc with debug information])],
         [enable_debug_info=yes],
         [enable_debug_info=no]
         )
@@ -65,7 +65,7 @@ AS_IF([test "x$enable_debug_info" != xyes],
 
 AS_IF([test "x$enable_debug_info" != xyes],
 	[AC_SUBST(debug_info, "")],
-	[AC_SUBST(debug_info, "-g")])
+	[AC_SUBST(debug_info, "-g3 -O0 -fvar-tracking-assignments")])
 
 AC_ARG_ENABLE(default-pie,
         [AS_HELP_STRING([--enable-default-pie],


### PR DESCRIPTION
The (--{enable,disable}-debug-info) option was previously not applied
to the build process of GCC (stage2), Binutils, and GDB.

And modify Makefile.in to explicitly set -O2 in CFLAGS and CXXFLAGS for
binutils, GDB, and GCC builds.

Also, update CFLAGS_FOR_TARGET and CXXFLAGS_FOR_TARGET to use -O2
instead of -Os, improving performance for the generated toolchain.

Signed-off-by: Luis Silva <luiss@synopsys.com>