### PR TITLE
arcv: Add picolibc allowlist

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -241,7 +241,7 @@ check-gdb-picolibc-nano: stamps/check-gdb-picolibc-nano
 
 .PHONY: report
 report: report-@default_target@
-.PHONY: report-linux report-newlib report-newlib-nano
+.PHONY: report-linux report-newlib report-newlib-nano report-picolibc report-picolibc-nano
 report-linux: $(patsubst %,report-%-linux,$(REGRESSION_TEST_LIST))
 report-newlib: $(patsubst %,report-%-newlib,$(REGRESSION_TEST_LIST))
 report-newlib-nano: $(patsubst %,report-%-newlib-nano,$(REGRESSION_TEST_LIST))
@@ -1787,6 +1787,13 @@ report-gcc-newlib: stamps/check-gcc-newlib
 
 report-gcc-newlib-nano: stamps/check-gcc-newlib-nano
 	$(srcdir)/scripts/testsuite-filter gcc newlib-nano $(srcdir)/test/allowlist `find build-gcc-newlib-stage2/gcc/testsuite/ -name *.sum |paste -sd "," -`
+
+.PHONY: report-gcc-picolibc report-gcc-picolibc-nano
+report-gcc-picolibc: stamps/check-gcc-picolibc
+	$(srcdir)/scripts/testsuite-filter gcc picolibc $(srcdir)/test/allowlist `find build-gcc-picolibc-stage2/gcc/testsuite/ -name *.sum |paste -sd "," -`
+
+report-gcc-picolib-nano: stamps/check-gcc-picolibc-nano
+	$(srcdir)/scripts/testsuite-filter gcc picolibc-nano $(srcdir)/test/allowlist `find build-gcc-picolibc-stage2/gcc/testsuite/ -name *.sum |paste -sd "," -`
 
 .PHONY: report-gcc-linux
 report-gcc-linux: stamps/check-gcc-linux

--- a/Makefile.in
+++ b/Makefile.in
@@ -136,6 +136,8 @@ NEWLIB_CXX_FOR_TARGET ?= $(NEWLIB_TUPLE)-g++
 NEWLIB_TARGET_BOARDS ?= $(shell $(srcdir)/scripts/generate_target_board \
   --sim-name riscv-sim \
   --cmodel $(shell echo @cmodel@ | cut -d '=' -f2) \
+  --mtune "$(if $(MTUNE_FOR_TARGET),$(MTUNE_FOR_TARGET),\
+	     $(shell echo @WITH_TUNE@ | cut -d '=' -f2))" \
   --build-arch-abi "$(NEWLIB_MULTILIB_NAMES)" \
   --extra-test-arch-abi-flags-list "$(EXTRA_MULTILIB_TEST)")
 

--- a/scripts/generate_target_board
+++ b/scripts/generate_target_board
@@ -21,12 +21,14 @@ def parse_options(argv):
                       default = '')
   parser.add_argument('--cmodel', type = str, default = 'medlow',
                       help = 'The name of the cmodel, like medlow.')
+  parser.add_argument('--mtune', type = str, default = '',
+                      help = 'The name of the mtune, like arc-v-rhx-100-series.')
 
   options = parser.parse_args()
   return options
 
 # Generate only one target board like below:
-#   riscv-sim/-march=rv64gcv_zvl256b/-mabi=lp64d/-mcmodel=medlow
+#   riscv-sim/-march=rv64gcv_zvl256b/-mabi=lp64d/-mcmodel=medlow/-mtune=arc-v-rhx-100-series (if mtune specified)
 # From the config_string like below, --param is optional
 #   rv64gcv_zvl128b-lp64d:--param=riscv-autovec-lmul=m1
 def generate_one_target_board(arch_abi, flags, options):
@@ -34,14 +36,20 @@ def generate_one_target_board(arch_abi, flags, options):
   arch = arch_and_abi[0]
   abi = arch_and_abi[1]
 
+  # Build base target board string
+  base_target = "{0}/-march={1}/-mabi={2}/-mcmodel={3}".format(
+    options.sim_name, arch, abi, options.cmodel)
+
+  # Add mtune if specified and not empty
+  if options.mtune and options.mtune.strip():
+    base_target += "/-mtune={0}".format(options.mtune)
+
   if len(flags) == 0:
-    return "{0}/-march={1}/-mabi={2}/-mcmodel={3}".format(
-      options.sim_name, arch, abi, options.cmodel)
+    return base_target
 
   flags = flags.replace(":", "/")
 
-  return "{0}/-march={1}/-mabi={2}/-mcmodel={3}/{4}".format(
-    options.sim_name, arch, abi, options.cmodel, flags)
+  return "{0}/{1}".format(base_target, flags)
 
 def main(argv):
   options = parse_options(argv)

--- a/scripts/testsuite-filter
+++ b/scripts/testsuite-filter
@@ -38,8 +38,8 @@ def usage():
           " <white-list-base-dir> <testsuite.sum>" % sys.argv[0])
 
 
-def get_white_list_files(raw_arch, abi, libc, white_list_base_dir):
-    """ Return white file list according the arch, abi, libc name and component.
+def get_white_list_files(raw_arch, abi, libc, white_list_base_dir, mtune=""):
+    """ Return white file list according the arch, abi, libc, mtune and component.
     """
     white_list_files = []
     arch = Arch(raw_arch)
@@ -101,6 +101,58 @@ def get_white_list_files(raw_arch, abi, libc, white_list_base_dir):
 
         filename = "%s.%s.%s.%s.log" % (libc, arch.base_arch, ext, abi)
         append_if_exist(filename)
+
+    # Add mtune-specific patterns if mtune is specified
+    if mtune:
+        filename = "%s.log" % (mtune)
+        append_if_exist(filename)
+
+        filename = "%s.%s.log" % (arch.base_arch, mtune)
+        append_if_exist(filename)
+
+        filename = "%s.%s.log" % (mtune, abi)
+        append_if_exist(filename)
+
+        filename = "%s.%s.%s.log" % (arch.base_arch, mtune, abi)
+        append_if_exist(filename)
+
+        filename = "%s.%s.log" % (libc, mtune)
+        append_if_exist(filename)
+
+        filename = "%s.%s.%s.log" % (libc, arch.base_arch, mtune)
+        append_if_exist(filename)
+
+        filename = "%s.%s.%s.log" % (libc, mtune, abi)
+        append_if_exist(filename)
+
+        filename = "%s.%s.%s.%s.log" % (libc, arch.base_arch, mtune, abi)
+        append_if_exist(filename)
+
+        # Add mtune patterns combined with extensions
+        for ext in arch.ext:
+            filename = "%s.%s.log" % (mtune, ext)
+            append_if_exist(filename)
+
+            filename = "%s.%s.%s.log" % (arch.base_arch, mtune, ext)
+            append_if_exist(filename)
+
+            filename = "%s.%s.%s.log" % (mtune, ext, abi)
+            append_if_exist(filename)
+
+            filename = "%s.%s.%s.%s.log" % (arch.base_arch, mtune, ext, abi)
+            append_if_exist(filename)
+
+            filename = "%s.%s.%s.log" % (libc, mtune, ext)
+            append_if_exist(filename)
+
+            filename = "%s.%s.%s.%s.log" % (libc, arch.base_arch, mtune, ext)
+            append_if_exist(filename)
+
+            filename = "%s.%s.%s.%s.log" % (libc, mtune, ext, abi)
+            append_if_exist(filename)
+
+            filename = "%s.%s.%s.%s.%s.log" % (libc, arch.base_arch, mtune, ext, abi)
+            append_if_exist(filename)
 
     return white_list_files
 
@@ -168,9 +220,9 @@ def read_sum(sum_files):
     return unexpected_results
 
 
-def get_white_list(arch, abi, libc, white_list_base_dir, is_gcc):
+def get_white_list(arch, abi, libc, white_list_base_dir, is_gcc, mtune=""):
     white_list_files = \
-        get_white_list_files(arch, abi, libc, white_list_base_dir)
+        get_white_list_files(arch, abi, libc, white_list_base_dir, mtune)
     white_list = read_white_lists(white_list_files, is_gcc)
     return white_list
 
@@ -187,6 +239,7 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
             arch = ""
             abi = ""
             cmodel = ""
+            mtune = ""
             other_args = []
             for info in variation.split('/'):
                 if info.startswith('-march'):
@@ -195,13 +248,16 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
                     abi = info[6:]
                 elif info.startswith('-mcmodel'):
                     cmodel = info[9:]
+                elif info.startswith('-mtune'):
+                    mtune = info[7:]
+                    other_args.append(info)
                 elif info != 'riscv-sim':
                     other_args.append(info)
 
             white_list = \
                 get_white_list(arch, abi, libc,
                                os.path.join(white_list_base_dir, tool),
-                               is_gcc)
+                               is_gcc, mtune)
             # filter!
             config = (arch, abi, cmodel, ":".join(other_args))
             fail_count = 0

--- a/test/allowlist/gcc/picolibc.arc-v-rhx-100-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rhx-100-series.log
@@ -1,0 +1,577 @@
+#
+# ARC-V RHX-100 (arc-2025.09 release known failures.)
+#
+FAIL: gcc.dg/pr49496.c (test for excess errors)
+FAIL: gcc.dg/pr69634.c (test for excess errors)
+FAIL: gcc.dg/pr90838-2.c scan-tree-dump forwprop2 "= \\.CTZ"
+FAIL: gcc.dg/pr94166.c (test for excess errors)
+FAIL: gcc.dg/pr94167.c (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O2  (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O3 -g  (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.dg/torture/pr113026-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   (test for bogus messages, line 10)
+FAIL: gcc.dg/tree-ssa/pr83403-1.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.dg/tree-ssa/pr83403-2.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.target/riscv/pr107455-2.c   -O0   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O1   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O2   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O3 -g   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -Os   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr116715.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/save-restore-3.c   -O2   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/save-restore-3.c   -O3 -g   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O3 -g   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O3 -g   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O0   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O1   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O2   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O3 -g   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -Os   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O3 -g   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -Os   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O1   scan-assembler th.extu\t
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O1   scan-assembler-not \\mslli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O1   scan-assembler-not \\msrli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2   scan-assembler th.extu\t
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2   scan-assembler-not \\mslli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2   scan-assembler-not \\msrli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O3 -g   scan-assembler th.extu\t
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O3 -g   scan-assembler-not \\mslli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O3 -g   scan-assembler-not \\msrli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler th.extu\t
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not \\mslli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not \\msrli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler th.extu\t
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not \\mslli
+FAIL: gcc.target/riscv/xtheadbb-extu.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not \\msrli
+FAIL: gcc.target/riscv/xtheadbs-tst.c   -O1   scan-assembler-times th.tst\t 1
+FAIL: gcc.target/riscv/xtheadbs-tst.c   -O2   scan-assembler-times th.tst\t 1
+FAIL: gcc.target/riscv/xtheadbs-tst.c   -O3 -g   scan-assembler-times th.tst\t 1
+FAIL: gcc.target/riscv/xtheadbs-tst.c   -Os   scan-assembler-times th.tst\t 1
+FAIL: gcc.target/riscv/xtheadbs-tst.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times th.tst\t 1
+FAIL: gcc.target/riscv/xtheadbs-tst.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times th.tst\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2   scan-assembler-times th.mula\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O3 -g   scan-assembler-times th.mula\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -Os   scan-assembler-times th.mula\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times th.mula\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times th.mula\t 1
+FAIL: gcc.target/riscv/zicond_ifcvt_opt.c   -O2   scan-assembler-times czero\\.eqz 36
+FAIL: gcc.target/riscv/zicond_ifcvt_opt.c   -O2   scan-assembler-times czero\\.nez 36
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-102.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-108.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-114.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-50.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-90.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-96.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_back_prop-19.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_back_prop-19.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_back_prop-19.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-23.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-23.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-23.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m1,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m1,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m1,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-6.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  scan-assembler-times ld\\s+a[0-1],\\s*[0-9]+\\(sp\\) 24
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-7.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  scan-assembler-times ld\\s+a[0-1],\\s*[0-9]+\\(sp\\) 24
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl (test for excess errors)
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O0  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O1  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O0  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O1  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-times vslideup 75
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-times vslidedown 75
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vrgather
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vmerge
+
+#
+# g++
+#
+FAIL: g++.dg/debug/ra1.C -gdwarf-2 -O2 (test for excess errors)
+FAIL: g++.dg/debug/ra1.C -gdwarf-2 -O3 (test for excess errors)
+FAIL: g++.dg/debug/ra1.C -gdwarf-2 -g3 -O2 (test for excess errors)
+FAIL: g++.dg/debug/ra1.C -gdwarf-2 -g3 -O3 (test for excess errors)
+FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++11 (test for excess errors)
+FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++17 (test for excess errors)
+FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++26 (test for excess errors)
+FAIL: g++.dg/opt/pr94618.C  -std=gnu++11 (test for excess errors)
+FAIL: g++.dg/opt/pr94618.C  -std=gnu++17 (test for excess errors)
+FAIL: g++.dg/opt/pr94618.C  -std=gnu++26 (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O2  (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O3 -g  (test for excess errors)
+FAIL: c-c++-common/torture/pr116189-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)

--- a/test/allowlist/gcc/picolibc.arc-v-rhx-100-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rhx-100-series.log
@@ -1,15 +1,8 @@
 #
 # ARC-V RHX-100 (arc-2025.09 release known failures.)
 #
-FAIL: gcc.dg/pr49496.c (test for excess errors)
 FAIL: gcc.dg/pr69634.c (test for excess errors)
 FAIL: gcc.dg/pr90838-2.c scan-tree-dump forwprop2 "= \\.CTZ"
-FAIL: gcc.dg/pr94166.c (test for excess errors)
-FAIL: gcc.dg/pr94167.c (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O2  (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O3 -g  (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
 FAIL: gcc.dg/torture/pr113026-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   (test for bogus messages, line 10)
 FAIL: gcc.dg/tree-ssa/pr83403-1.c scan-tree-dump-times lim2 "Executing store motion of" 10
 FAIL: gcc.dg/tree-ssa/pr83403-2.c scan-tree-dump-times lim2 "Executing store motion of" 10
@@ -558,6 +551,26 @@ UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 
 UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vrgather
 UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vmerge
 
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O0   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O1   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O2   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O3 -g   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -Os   check-function-bodies interrupt
+
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1di_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2si_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
+
+FAIL: gcc.target/riscv/rvv/base/spill-10.c check-function-bodies stach_check_alloca_1
+FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_1
+FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_2
+FAIL: gcc.target/riscv/rvv/base/spill-9.c check-function-bodies stach_check_alloca_1
+
 #
 # g++
 #
@@ -565,13 +578,6 @@ FAIL: g++.dg/debug/ra1.C -gdwarf-2 -O2 (test for excess errors)
 FAIL: g++.dg/debug/ra1.C -gdwarf-2 -O3 (test for excess errors)
 FAIL: g++.dg/debug/ra1.C -gdwarf-2 -g3 -O2 (test for excess errors)
 FAIL: g++.dg/debug/ra1.C -gdwarf-2 -g3 -O3 (test for excess errors)
-FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++11 (test for excess errors)
-FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++17 (test for excess errors)
-FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++26 (test for excess errors)
 FAIL: g++.dg/opt/pr94618.C  -std=gnu++11 (test for excess errors)
 FAIL: g++.dg/opt/pr94618.C  -std=gnu++17 (test for excess errors)
 FAIL: g++.dg/opt/pr94618.C  -std=gnu++26 (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O2  (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O3 -g  (test for excess errors)
-FAIL: c-c++-common/torture/pr116189-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)

--- a/test/allowlist/gcc/picolibc.arc-v-rmx-100-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rmx-100-series.log
@@ -1,0 +1,636 @@
+#
+# ARC-V RMX-100 (arc-2025.09 release known failures.)
+#
+FAIL: gcc.dg/pr90838-2.c scan-tree-dump forwprop2 "= \\.CTZ"
+FAIL: gcc.dg/torture/pr113026-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   (test for bogus messages, line 10)
+FAIL: gcc.dg/tree-ssa/pr83403-1.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.dg/tree-ssa/pr83403-2.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O0  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O1  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O2  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O3 -g  execution test
+FAIL: gcc.target/riscv/pr113095.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -Os  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.target/riscv/pr116715.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O0   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O1   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O2   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -g   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -Os   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O0   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O1   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O2   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -g   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -Os   check-function-bodies bar
+FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O3 -g   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -Os   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O1   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O2   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O3 -g   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O1   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O2   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O3 -g   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/rvv/base/spill-7.c check-function-bodies spill
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli 1
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl (test for excess errors)
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O0  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O1  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O0  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O1  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-times vslideup 75
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-times vslidedown 75
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vrgather
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vmerge

--- a/test/allowlist/gcc/picolibc.arc-v-rmx-100-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rmx-100-series.log
@@ -122,18 +122,6 @@ FAIL: gcc.target/riscv/pr117690.c   -O3 -g  (test for excess errors)
 FAIL: gcc.target/riscv/pr117690.c   -Os  (test for excess errors)
 FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
 FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O0   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O1   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O2   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -g   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -Os   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O0   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O1   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O2   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -g   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -Os   check-function-bodies bar
 FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
 FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
 FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
@@ -180,12 +168,6 @@ FAIL: gcc.target/riscv/zicond-xor-01.c   -O3 -g   scan-assembler-times \\mczero.
 FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mczero.eqz\\M 1
 FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mczero.eqz\\M 1
 FAIL: gcc.target/riscv/rvv/base/spill-7.c check-function-bodies spill
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli 1
 FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
 FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
 FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0

--- a/test/allowlist/gcc/picolibc.arc-v-rmx-500-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rmx-500-series.log
@@ -1,0 +1,636 @@
+#
+# ARC-V RMX-500 (arc-2025.09 release known failures.)
+#
+FAIL: gcc.dg/pr90838-2.c scan-tree-dump forwprop2 "= \\.CTZ"
+FAIL: gcc.dg/torture/pr113026-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   (test for bogus messages, line 10)
+FAIL: gcc.dg/tree-ssa/pr83403-1.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.dg/tree-ssa/pr83403-2.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O0  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O1  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O2  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O3 -g  execution test
+FAIL: gcc.target/riscv/pr113095.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -Os  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/pr113095.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.target/riscv/pr116715.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr116715.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O0   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O1   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O2   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -g   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_1.c   -Os   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O0   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O1   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O2   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -g   check-function-bodies bar
+FAIL: gcc.target/riscv/stack_save_restore_2.c   -Os   check-function-bodies bar
+FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O3 -g   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -Os   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O1   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O2   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O3 -g   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/xventanacondops-xor-01.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vt\\.maskc\t 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O0   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O1   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O3 -g   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -Os   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\msh2add 2
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\msh1add 1
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mslli 3
+FAIL: gcc.target/riscv/zba-shNadd-07.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mmul 2
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O1   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O2   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O3 -g   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mczero.eqz\\M 1
+FAIL: gcc.target/riscv/rvv/base/spill-7.c check-function-bodies spill
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli 1
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 12
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmax-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmax\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 2
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmin-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmin\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 4
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-2.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 6
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-3.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-4.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
+FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fmul-5.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times vfmul\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 9
+FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl (test for excess errors)
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-1-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-10-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-12-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-13-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-14-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-17-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-18-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-22-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-23-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-4-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-5-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-6-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-7-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-9-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data16-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-CCIT-data8-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/crc-coremark-16bitdata-zbc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O0  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O1  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr116715.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O0  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O1  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O3 -g  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -Os  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  compilation failed to produce executable
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-times vslideup 75
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-times vslidedown 75
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vrgather
+UNRESOLVED: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl  scan-assembler-not vmerge

--- a/test/allowlist/gcc/picolibc.arc-v-rmx-500-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rmx-500-series.log
@@ -122,18 +122,6 @@ FAIL: gcc.target/riscv/pr117690.c   -O3 -g  (test for excess errors)
 FAIL: gcc.target/riscv/pr117690.c   -Os  (test for excess errors)
 FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
 FAIL: gcc.target/riscv/pr117690.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O0   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O1   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O2   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -O3 -g   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_1.c   -Os   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O0   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O1   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O2   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -O3 -g   check-function-bodies bar
-FAIL: gcc.target/riscv/stack_save_restore_2.c   -Os   check-function-bodies bar
 FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
 FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
 FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times lw\t[a-x0-9]+,%tlsdesc_load_lo 1
@@ -180,12 +168,6 @@ FAIL: gcc.target/riscv/zicond-xor-01.c   -O3 -g   scan-assembler-times \\mczero.
 FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\mczero.eqz\\M 1
 FAIL: gcc.target/riscv/zicond-xor-01.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\mczero.eqz\\M 1
 FAIL: gcc.target/riscv/rvv/base/spill-7.c check-function-bodies spill
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2   scan-assembler-times vsetivli 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli\\s+zero,\\s*0,\\s*e64,\\s*m4,\\s*t[au],\\s*m[au] 1
-FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-98.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli 1
 FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0
 FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vf\\s+v[0-9]+,v[0-9]+,fa[0-9],v0.t 18
 FAIL: gcc.target/riscv/rvv/autovec/cond/cond_fadd-2.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times vfadd\\.vv\\s+v[0-9]+,v[0-9]+,v[0-9]+,v0.t 0

--- a/test/allowlist/gcc/picolibc.arc-v-rpx-100-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rpx-100-series.log
@@ -1,0 +1,265 @@
+#
+# ARC-V RPX-100 (arc-2025.09 release known failures.)
+#
+FAIL: gcc.dg/pr49496.c (test for excess errors)
+FAIL: gcc.dg/pr50017.c (test for excess errors)
+FAIL: gcc.dg/pr64935-1.c (test for excess errors)
+FAIL: gcc.dg/pr94166.c (test for excess errors)
+FAIL: c-c++-common/pr44832.c  -Wc++-compat  (test for excess errors)
+FAIL: gcc.dg/torture/pr107115.c   -O2  execution test
+FAIL: gcc.dg/torture/pr107115.c   -O3 -g  execution test
+FAIL: gcc.dg/vect/pr65310.c scan-tree-dump vect "can't force alignment"
+FAIL: gcc.dg/vect/pr65310.c scan-tree-dump-not vect "misalign = 0"
+FAIL: gcc.dg/vect/pr88598-1.c scan-tree-dump-not optimized "REDUC_PLUS"
+FAIL: gcc.dg/vect/pr88598-2.c scan-tree-dump-not optimized "REDUC_PLUS"
+FAIL: gcc.dg/vect/pr88598-3.c scan-tree-dump-not optimized "REDUC_PLUS"
+FAIL: gcc.dg/vect/vect-gather-2.c scan-tree-dump vect "different gather base"
+FAIL: gcc.dg/vect/vect-gather-2.c scan-tree-dump vect "different gather scale"
+FAIL: gcc.dg/vect/pr65310.c -flto -ffat-lto-objects  scan-tree-dump vect "can't force alignment"
+FAIL: gcc.dg/vect/pr65310.c -flto -ffat-lto-objects  scan-tree-dump-not vect "misalign = 0"
+FAIL: gcc.dg/vect/pr88598-1.c -flto -ffat-lto-objects  scan-tree-dump-not optimized "REDUC_PLUS"
+FAIL: gcc.dg/vect/pr88598-2.c -flto -ffat-lto-objects  scan-tree-dump-not optimized "REDUC_PLUS"
+FAIL: gcc.dg/vect/pr88598-3.c -flto -ffat-lto-objects  scan-tree-dump-not optimized "REDUC_PLUS"
+FAIL: gcc.dg/vect/vect-gather-2.c -flto -ffat-lto-objects  scan-tree-dump vect "different gather base"
+FAIL: gcc.dg/vect/vect-gather-2.c -flto -ffat-lto-objects  scan-tree-dump vect "different gather scale"
+FAIL: gcc.target/riscv/pr107455-2.c   -O0   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O1   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O2   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O3 -g   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -Os   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr107455-2.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not li\\ta0,0
+FAIL: gcc.target/riscv/pr111501.c   -O1   scan-assembler-times srli\t 2
+FAIL: gcc.target/riscv/pr111501.c   -O1   scan-assembler-times slli\ta[0-9],a[0-9],16 2
+FAIL: gcc.target/riscv/pr111501.c   -O2   scan-assembler-times srli\t 2
+FAIL: gcc.target/riscv/pr111501.c   -O2   scan-assembler-times slli\ta[0-9],a[0-9],16 2
+FAIL: gcc.target/riscv/pr111501.c   -O3 -g   scan-assembler-times srli\t 2
+FAIL: gcc.target/riscv/pr111501.c   -O3 -g   scan-assembler-times slli\ta[0-9],a[0-9],16 2
+FAIL: gcc.target/riscv/save-restore-3.c   -O2   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/save-restore-3.c   -O3 -g   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O3 -g   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O3 -g   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not call[ \t]*t0,__riscv_save_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-not tail[ \t]*__riscv_restore_0
+FAIL: gcc.target/riscv/save-restore-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler tail[ \t]*foo
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O0   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O1   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O2   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O3 -g   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -Os   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/stack-check-cfa-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\.cfi_def_cfa [0-9]+, 0 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times ld\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times ld\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times ld\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O3 -g   scan-assembler-times ld\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -Os   scan-assembler-times ld\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times ld\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times ld\t[a-x0-9]+,%tlsdesc_load_lo 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2   scan-assembler-times th.mulaw\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2   scan-assembler-times th.mulah\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O3 -g   scan-assembler-times th.mulaw\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O3 -g   scan-assembler-times th.mulah\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -Os   scan-assembler-times th.mulaw\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -Os   scan-assembler-times th.mulah\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times th.mulaw\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times th.mulah\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times th.mulaw\t 1
+FAIL: gcc.target/riscv/xtheadmac-mula-muls.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times th.mulah\t 1
+FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O1   scan-assembler slli\ta[0-9],a[0-9],34
+FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O1   scan-assembler slli\ta[0-9],a[0-9],9
+FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O2   scan-assembler slli\ta[0-9],a[0-9],34
+FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O2   scan-assembler slli\ta[0-9],a[0-9],9
+FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O3 -g   scan-assembler slli\ta[0-9],a[0-9],34
+FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O3 -g   scan-assembler slli\ta[0-9],a[0-9],9
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O1   scan-assembler-times srli\t 54
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O1   scan-assembler-times srliw\t 7
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O2   scan-assembler-times slli\t 36
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O2   scan-assembler-times srli\t 54
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O2   scan-assembler-times srliw\t 7
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O3 -g   scan-assembler-times slli\t 36
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O3 -g   scan-assembler-times srli\t 54
+FAIL: gcc.target/riscv/zero-extend-rshift.c   -O3 -g   scan-assembler-times srliw\t 7
+FAIL: gcc.target/riscv/zicond_ifcvt_opt.c   -O2   scan-assembler-times czero\\.eqz 36
+FAIL: gcc.target/riscv/zicond_ifcvt_opt.c   -O2   scan-assembler-times czero\\.nez 36
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -O2  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -O3  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -Ofast  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -Os  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_s_sub-1-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_s_sub-2-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_s_sub-3-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_s_sub-4-i32.c -Oz  check-function-bodies sat_s_sub_int32_t_fmt_4
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-102.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-108.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-114.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-50.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-90.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/binop_vx_constraint-96.c scan-assembler-times vlse64\\.v\\s+v[0-9]+,\\s*0\\([a-x0-9]+\\),\\s*zero\\s+\\.L[0-9]+\\:\\s+ 1
+FAIL: gcc.target/riscv/rvv/base/cpymem-1.c check-function-bodies f3
+FAIL: gcc.target/riscv/rvv/base/cpymem-2.c check-function-bodies f1
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmacc_2x8x2.c check-function-bodies test_sf_vqmacc_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccsu_2x8x2.c check-function-bodies test_sf_vqmaccsu_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccu_2x8x2.c check-function-bodies test_sf_vqmaccu_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_i32m8_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_i32m8_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xsfvector/sf_vqmaccus_2x8x2.c check-function-bodies test_sf_vqmaccus_2x8x2_tu_vint32m8_t
+FAIL: gcc.target/riscv/rvv/xtheadvector/pr114194-rv64.c check-function-bodies foo0_7
+FAIL: gcc.target/riscv/rvv/xtheadvector/pr114194-rv64.c check-function-bodies foo1_5
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_back_prop-19.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_back_prop-19.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_back_prop-19.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-21.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-22.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-23.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-23.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-23.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m1,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m1,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*mf2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m1,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m2,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m4,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-24.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e8,\\s*m8,\\s*t[au],\\s*m[au]\\s+\\.L[0-9][0-9]\\: 1
+FAIL: gcc.target/riscv/rvv/autovec/pr113206-2.c -O3 -ftree-vectorize  scan-assembler-times li\\s+[a-x0-9]+,\\s*32 1
+FAIL: gcc.target/riscv/rvv/autovec/pr113206-2.c -O3 -ftree-vectorize  scan-assembler-times vsetvli 1
+FAIL: gcc.target/riscv/rvv/autovec/pr116059.c -O3 -ftree-vectorize execution test
+FAIL: gcc.target/riscv/rvv/autovec/pr117383.c -O3 -ftree-vectorize execution test
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-6.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  scan-assembler-times ld\\s+a[0-1],\\s*[0-9]+\\(sp\\) 24
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-7.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  scan-assembler-times ld\\s+a[0-1],\\s*[0-9]+\\(sp\\) 24
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/unop/popcount-run-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m4 execution test
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/unop/popcount-run-1.c -ftree-vectorize -O3 -mrvv-max-lmul=m8 execution test
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/unop/popcount-run-1.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic execution test
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/unop/popcount-run-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m4 execution test
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/unop/popcount-run-1.c -ftree-vectorize -O2 -mrvv-max-lmul=m8 execution test
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv64gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/unop/popcount-run-1.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic execution test
+FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-evenodd-run.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl execution test
+FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide-run.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl execution test
+
+#
+# g++
+#
+FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++11 (test for excess errors)
+FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++17 (test for excess errors)
+FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++26 (test for excess errors)
+FAIL: g++.dg/opt/pr94618.C  -std=gnu++11 (test for excess errors)
+FAIL: g++.dg/opt/pr94618.C  -std=gnu++17 (test for excess errors)
+FAIL: g++.dg/opt/pr94618.C  -std=gnu++26 (test for excess errors)
+FAIL: g++.dg/tree-ssa/copyprop.C   (test for excess errors)
+FAIL: g++.dg/modules/pr105169 link

--- a/test/allowlist/gcc/picolibc.arc-v-rpx-100-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rpx-100-series.log
@@ -1,11 +1,6 @@
 #
 # ARC-V RPX-100 (arc-2025.09 release known failures.)
 #
-FAIL: gcc.dg/pr49496.c (test for excess errors)
-FAIL: gcc.dg/pr50017.c (test for excess errors)
-FAIL: gcc.dg/pr64935-1.c (test for excess errors)
-FAIL: gcc.dg/pr94166.c (test for excess errors)
-FAIL: c-c++-common/pr44832.c  -Wc++-compat  (test for excess errors)
 FAIL: gcc.dg/torture/pr107115.c   -O2  execution test
 FAIL: gcc.dg/torture/pr107115.c   -O3 -g  execution test
 FAIL: gcc.dg/vect/pr65310.c scan-tree-dump vect "can't force alignment"
@@ -80,10 +75,8 @@ FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O3 -g   scan-assembler slli\ta
 FAIL: gcc.target/riscv/zero-extend-rshift-64.c   -O3 -g   scan-assembler slli\ta[0-9],a[0-9],9
 FAIL: gcc.target/riscv/zero-extend-rshift.c   -O1   scan-assembler-times srli\t 54
 FAIL: gcc.target/riscv/zero-extend-rshift.c   -O1   scan-assembler-times srliw\t 7
-FAIL: gcc.target/riscv/zero-extend-rshift.c   -O2   scan-assembler-times slli\t 36
 FAIL: gcc.target/riscv/zero-extend-rshift.c   -O2   scan-assembler-times srli\t 54
 FAIL: gcc.target/riscv/zero-extend-rshift.c   -O2   scan-assembler-times srliw\t 7
-FAIL: gcc.target/riscv/zero-extend-rshift.c   -O3 -g   scan-assembler-times slli\t 36
 FAIL: gcc.target/riscv/zero-extend-rshift.c   -O3 -g   scan-assembler-times srli\t 54
 FAIL: gcc.target/riscv/zero-extend-rshift.c   -O3 -g   scan-assembler-times srliw\t 7
 FAIL: gcc.target/riscv/zicond_ifcvt_opt.c   -O2   scan-assembler-times czero\\.eqz 36
@@ -252,12 +245,29 @@ FAIL: gcc.target/riscv/rvv/autovec/unop/popcount-run-1.c -ftree-vectorize -O2 -m
 FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-evenodd-run.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl execution test
 FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide-run.c -std=c99 -O3 -ftree-vectorize -mrvv-vector-bits=zvl execution test
 
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O0   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O1   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O2   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O3 -g   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -Os   check-function-bodies interrupt
+
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1di_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2si_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
+
+FAIL: gcc.target/riscv/rvv/base/spill-10.c check-function-bodies stach_check_alloca_1
+FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_1
+FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_2
+FAIL: gcc.target/riscv/rvv/base/spill-9.c check-function-bodies stach_check_alloca_1
+
 #
 # g++
 #
-FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++11 (test for excess errors)
-FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++17 (test for excess errors)
-FAIL: g++.dg/cpp0x/pr81325.C  -std=gnu++26 (test for excess errors)
 FAIL: g++.dg/opt/pr94618.C  -std=gnu++11 (test for excess errors)
 FAIL: g++.dg/opt/pr94618.C  -std=gnu++17 (test for excess errors)
 FAIL: g++.dg/opt/pr94618.C  -std=gnu++26 (test for excess errors)

--- a/test/allowlist/gcc/picolibc.log
+++ b/test/allowlist/gcc/picolibc.log
@@ -1,0 +1,555 @@
+#
+# Common to all ARC-V mtunes (arc-2025.09 release known failures.)
+#
+FAIL: c-c++-common/analyzer/isatty-1.c (test for excess errors)
+FAIL: c-c++-common/analyzer/isatty-1.c  (test for warnings, line 32)
+FAIL: c-c++-common/analyzer/isatty-1.c  (test for warnings, line 47)
+FAIL: c-c++-common/analyzer/isatty-1.c  (test for warnings, line 57)
+FAIL: c-c++-common/spec-barrier-1.c  -Wc++-compat  (test for excess errors)
+FAIL: gcc.c-torture/execute/960521-1.c   -O0  execution test
+FAIL: gcc.c-torture/execute/960521-1.c   -O1  execution test
+FAIL: gcc.c-torture/execute/960521-1.c   -O2  execution test
+FAIL: gcc.c-torture/execute/960521-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.c-torture/execute/960521-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.c-torture/execute/960521-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+FAIL: gcc.c-torture/execute/960521-1.c   -O3 -g  execution test
+FAIL: gcc.c-torture/execute/960521-1.c   -Os  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -O0  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -O1  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -O2  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -O3 -g  execution test
+FAIL: gcc.c-torture/execute/memcpy-1.c   -Os  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -O0  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -O1  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -O2  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -O3 -g  execution test
+FAIL: gcc.c-torture/execute/pr28982b.c   -Os  execution test
+FAIL: gcc.dg/lto/20081120-1 c_lto_20081120-1_0.o-c_lto_20081120-1_1.o link, -flto -r -nostdlib
+FAIL: gcc.dg/lto/20081120-2 c_lto_20081120-2_0.o-c_lto_20081120-2_1.o link, -flto -flto-partition=1to1 -r -nostdlib
+FAIL: gcc.dg/lto/20081204-1 c_lto_20081204-1_0.o-c_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
+FAIL: gcc.dg/lto/20081212-1 c_lto_20081212-1_0.o-c_lto_20081212-1_0.o link, -r -nostdlib
+FAIL: gcc.dg/lto/20081224 c_lto_20081224_0.o-c_lto_20081224_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
+FAIL: gcc.dg/lto/20090116 c_lto_20090116_0.o-c_lto_20090116_0.o link, -O1 -flto -flto-partition=1to1 -fPIC
+FAIL: gcc.dg/lto/20090126-1 c_lto_20090126-1_0.o-c_lto_20090126-1_0.o link, -O0 -flto -flto-partition=1to1
+FAIL: gcc.dg/lto/20090126-2 c_lto_20090126-2_0.o-c_lto_20090126-2_0.o link, -fPIC -O2 -flto -flto-partition=1to1
+FAIL: gcc.dg/lto/20090219 c_lto_20090219_0.o-c_lto_20090219_0.o link, -O3 -flto -flto-partition=1to1 -fPIC -r -nostdlib
+FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -flto
+FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -O2 -flto
+FAIL: gcc.dg/lto/20091014-1 c_lto_20091014-1_0.o-c_lto_20091014-1_0.o link, -fPIC -r -nostdlib -flto
+FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto
+FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto -flto-partition=1to1
+FAIL: gcc.dg/lto/20091016-1 c_lto_20091016-1_0.o-c_lto_20091016-1_1.o link, -fPIC -r -nostdlib -O2 -flto
+FAIL: gcc.dg/lto/20091020-1 c_lto_20091020-1_0.o-c_lto_20091020-1_1.o link, -fPIC -r -nostdlib -flto
+FAIL: gcc.dg/lto/20091020-2 c_lto_20091020-2_0.o-c_lto_20091020-2_1.o link, -fPIC -r -nostdlib -flto
+FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -fuse-linker-plugin
+FAIL: gcc.dg/lto/20100426 c_lto_20100426_0.o-c_lto_20100426_0.o link, -r -nostdlib -flto -g
+FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -fuse-linker-plugin
+FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -fuse-linker-plugin
+FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -fuse-linker-plugin
+FAIL: gcc.dg/lto/20111213-1 c_lto_20111213-1_0.o-c_lto_20111213-1_0.o link,  -flto -g 
+FAIL: gcc.dg/lto/pr45736 c_lto_pr45736_0.o-c_lto_pr45736_0.o link, -flto -r -O
+FAIL: gcc.dg/lto/pr52634 c_lto_pr52634_0.o-c_lto_pr52634_1.o link,  -flto -r -flto-partition=1to1 
+FAIL: gcc.dg/lto/pr54702 c_lto_pr54702_0.o-c_lto_pr54702_1.o link,  -O2 -flto -w 
+FAIL: gcc.dg/lto/pr59323-2 c_lto_pr59323-2_0.o-c_lto_pr59323-2_0.o link,  -O2 -g -flto 
+FAIL: gcc.dg/lto/pr59323 c_lto_pr59323_0.o-c_lto_pr59323_0.o link,  -O2 -g -flto 
+FAIL: gcc.dg/lto/pr60820 c_lto_pr60820_0.o-c_lto_pr60820_1.o link, -flto -r -nostdlib -O2
+FAIL: gcc.dg/lto/pr81406 c_lto_pr81406_0.o-c_lto_pr81406_0.o link,  -O2 -g -flto 
+FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O0 -flto -fsanitize=null 
+FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O2 -flto -fsanitize=null 
+FAIL: gcc.dg/lto/pr85870 c_lto_pr85870_0.o-c_lto_pr85870_1.o link,  -flto -O2 
+FAIL: gcc.dg/pr114713.c execution test
+FAIL: gcc.dg/tls/vis-attr-hidden.c scan-ipa-dump whole-program "Varpool flags: tls-local-dynamic"
+FAIL: gcc.dg/tls/vis-flag-hidden.c scan-ipa-dump whole-program "Varpool flags: tls-local-dynamic"
+FAIL: gcc.dg/tls/vis-pragma-hidden.c scan-ipa-dump whole-program "Varpool flags: tls-local-dynamic"
+FAIL: gcc.dg/tree-ssa/update-threading.c scan-tree-dump-times optimized "Invalid sum" 0
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-1.c scan-assembler e32,m1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-1.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-1.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 3
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-2.c scan-assembler e32,m1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-2.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-2.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 3
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-3.c scan-assembler e8,m1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-3.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-3.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 3
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-4.c scan-assembler e32,m1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-4.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-4.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 3
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-5.c scan-assembler e32,m1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-5.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-5.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 3
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-6.c scan-assembler e8,m1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-6.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-6.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 3
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-7.c scan-assembler e32,m1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul1-7.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 3
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-1.c scan-assembler e32,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-1.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-1.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-2.c scan-assembler e8,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-2.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-2.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-3.c scan-assembler e32,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-3.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-3.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-4.c scan-assembler e32,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-4.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-4.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-5.c scan-assembler e32,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-5.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-5.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-6.c scan-assembler e32,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-6.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul2-6.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-12.c scan-assembler-not e32,m8
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-12.c scan-assembler-times e32,m4 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-12.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-1.c scan-assembler e32,m4
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-1.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-1.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-2.c scan-assembler e8,m4
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-2.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-2.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-3.c scan-tree-dump-times vect "Maximum lmul = 2" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-3.c scan-tree-dump-times vect "Maximum lmul = 8" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-5.c scan-assembler e16,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-5.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-5.c scan-tree-dump-times vect "Maximum lmul = 2" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-5.c scan-tree-dump-times vect "Maximum lmul = 8" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-5.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-5.c scan-tree-dump vect "2: type = unsigned short, start = 0, end = 34"
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-5.c scan-tree-dump vect "start = 8, end = 10"
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-7.c scan-assembler e64,m4
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-7.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-7.c scan-tree-dump-times vect "Maximum lmul = 8" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul4-7.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul8-11.c scan-tree-dump-times vect "Maximum lmul = 8" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul8-2.c scan-tree-dump-times vect "Maximum lmul = 2" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul8-2.c scan-tree-dump-times vect "Maximum lmul = 8" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul8-4.c scan-tree-dump-times vect "Maximum lmul = 8" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul-mixed-1.c scan-assembler e32,m2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul-mixed-1.c scan-assembler-not csrr
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/dynamic-lmul-mixed-1.c scan-tree-dump-times vect "Preferring smaller LMUL loop because it has unexpected spills" 2
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/pr113112-2.c scan-tree-dump-times vect "Maximum lmul = 4, At most 16 number of live V_REG" 1
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/pr113112-4.c scan-assembler e64,m4
+FAIL: gcc.dg/vect/costmodel/riscv/rvv/pr113112-4.c scan-assembler-not e64,m2
+FAIL: gcc.target/riscv/attribute-1.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-1.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-1.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-1.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-1.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-5.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-5.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-5.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-5.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/attribute-5.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/cpymemsi-2.c   -O1   scan-assembler-times \t(call|tail)\tmemcpy 6
+FAIL: gcc.target/riscv/cpymemsi-2.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \t(call|tail)\tmemcpy 6
+FAIL: gcc.target/riscv/cpymemsi-2.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \t(call|tail)\tmemcpy 6
+FAIL: gcc.target/riscv/cpymemsi-2.c   -O2   scan-assembler-times \t(call|tail)\tmemcpy 6
+FAIL: gcc.target/riscv/cpymemsi-2.c   -O3 -g   scan-assembler-times \t(call|tail)\tmemcpy 6
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O0   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O1   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O2   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -O3 -g   check-function-bodies interrupt
+FAIL: gcc.target/riscv/interrupt-misaligned.c   -Os   check-function-bodies interrupt
+FAIL: gcc.target/riscv/round.c   -O0  (test for excess errors)
+FAIL: gcc.target/riscv/round.c   -O1  (test for excess errors)
+FAIL: gcc.target/riscv/round.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: gcc.target/riscv/round.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: gcc.target/riscv/round.c   -O2  (test for excess errors)
+FAIL: gcc.target/riscv/round.c   -O3 -g  (test for excess errors)
+FAIL: gcc.target/riscv/round.c   -Os  (test for excess errors)
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vadd-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfadd\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m1  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m2  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m4  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O2 -mrvv-max-lmul=m8  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=dynamic  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m1  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m2  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m4  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfrsub\\.vf 6
+FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfsub\\.vv 3
+FAIL: gcc.target/riscv/rvv/autovec/bug-3.c -O3 -ftree-vectorize  check-function-bodies foo
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1di_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2si_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
+FAIL: gcc.target/riscv/rvv/base/cpymem-strategy-2.c scan-assembler-times call\\tmemcpy 1
+FAIL: gcc.target/riscv/rvv/base/setmem-1.c check-function-bodies f2
+FAIL: gcc.target/riscv/rvv/base/setmem-1.c check-function-bodies f3
+FAIL: gcc.target/riscv/rvv/base/spill-10.c check-function-bodies stach_check_alloca_1
+FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_1
+FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_2
+FAIL: gcc.target/riscv/rvv/base/spill-9.c check-function-bodies stach_check_alloca_1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O0   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O1   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O2   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O3 -g   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -Os   scan-assembler-times vsetivli\\tzero,\\s*1 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-37.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times \\.L[0-9]+\\:\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+add\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[a-x0-9]+\\s+\\.L[0-9]+\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-37.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \\.L[0-9]+\\:\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+add\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[a-x0-9]+\\s+\\.L[0-9]+\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-37.c   -O2   scan-assembler-times \\.L[0-9]+\\:\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[0-9]00\\s+add\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*[a-x0-9]+\\s+\\.L[0-9]+\\: 1
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-67.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli 4
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-67.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+zero,\\s*[a-x0-9]+,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 4
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-67.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli 4
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-67.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+zero,\\s*[a-x0-9]+,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 4
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-67.c   -O2   scan-assembler-times vsetvli 4
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-67.c   -O2   scan-assembler-times vsetvli\\s+zero,\\s*[a-x0-9]+,\\s*e8,\\s*mf8,\\s*t[au],\\s*m[au] 4
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-68.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-68.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-68.c   -O2   scan-assembler-times vsetvli 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-71.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-71.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetvli\\s+zero,\\s*[a-x0-9]+,\\s*e8,\\s*mf8,\\s*tu,\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-71.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-71.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times vsetvli\\s+zero,\\s*[a-x0-9]+,\\s*e8,\\s*mf8,\\s*tu,\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-71.c   -O2   scan-assembler-times vsetvli 2
+FAIL: gcc.target/riscv/rvv/vsetvl/avl_single-71.c   -O2   scan-assembler-times vsetvli\\s+zero,\\s*[a-x0-9]+,\\s*e8,\\s*mf8,\\s*tu,\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle16\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle16\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle16\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-17.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle16\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle16\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle16\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-18.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle8\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-19.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-19.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-19.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vle32\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-20.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vlm\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 6
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-20.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vlm\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-20.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vlm\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 6
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-20.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vlm\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-20.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9][0-9]\\:\\s+vlm\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 6
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_bb_prop-20.c   -O2   scan-assembler-times add\\ta[0-7],a[0-7],a[0-7]\\s+\\.L[0-9]\\:\\s+vlm\\.v\\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),0\\s*\\([a-x0-9]+\\) 1
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_switch_vtype-4.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_switch_vtype-4.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au] 3
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_switch_vtype-5.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e16,\\s*mf2,\\s*t[au],\\s*m[au] 2
+FAIL: gcc.target/riscv/rvv/vsetvl/vlmax_switch_vtype-5.c   -O2   scan-assembler-times vsetvli\\s+[a-x0-9]+,\\s*zero,\\s*e32,\\s*mf2,\\s*t[au],\\s*m[au] 3
+FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times addi\ta0,[a-x0-9]+,%tlsdesc_add_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times auipc\t[a-x0-9]+,%tlsdesc_hi 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O0   scan-assembler-times jalr\tt0,[a-x0-9]+,%tlsdesc_call 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times addi\ta0,[a-x0-9]+,%tlsdesc_add_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times auipc\t[a-x0-9]+,%tlsdesc_hi 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O1   scan-assembler-times jalr\tt0,[a-x0-9]+,%tlsdesc_call 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times addi\ta0,[a-x0-9]+,%tlsdesc_add_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times auipc\t[a-x0-9]+,%tlsdesc_hi 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times jalr\tt0,[a-x0-9]+,%tlsdesc_call 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times addi\ta0,[a-x0-9]+,%tlsdesc_add_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times auipc\t[a-x0-9]+,%tlsdesc_hi 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times jalr\tt0,[a-x0-9]+,%tlsdesc_call 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times addi\ta0,[a-x0-9]+,%tlsdesc_add_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times auipc\t[a-x0-9]+,%tlsdesc_hi 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O2   scan-assembler-times jalr\tt0,[a-x0-9]+,%tlsdesc_call 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O3 -g   scan-assembler-times addi\ta0,[a-x0-9]+,%tlsdesc_add_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O3 -g   scan-assembler-times auipc\t[a-x0-9]+,%tlsdesc_hi 1
+FAIL: gcc.target/riscv/tlsdesc.c   -O3 -g   scan-assembler-times jalr\tt0,[a-x0-9]+,%tlsdesc_call 1
+FAIL: gcc.target/riscv/tlsdesc.c   -Os   scan-assembler-times addi\ta0,[a-x0-9]+,%tlsdesc_add_lo 1
+FAIL: gcc.target/riscv/tlsdesc.c   -Os   scan-assembler-times auipc\t[a-x0-9]+,%tlsdesc_hi 1
+FAIL: gcc.target/riscv/tlsdesc.c   -Os   scan-assembler-times jalr\tt0,[a-x0-9]+,%tlsdesc_call 1
+FAIL: scan-symbol exported_var: output file does not exist
+UNRESOLVED: gcc.target/riscv/attribute-1.c   -O0   scan-assembler .attribute arch
+UNRESOLVED: gcc.target/riscv/attribute-1.c   -O1   scan-assembler .attribute arch
+UNRESOLVED: gcc.target/riscv/attribute-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler .attribute arch
+UNRESOLVED: gcc.target/riscv/attribute-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler .attribute arch
+UNRESOLVED: gcc.target/riscv/attribute-1.c   -O2   scan-assembler .attribute arch
+UNRESOLVED: gcc.target/riscv/attribute-1.c   -O3 -g   scan-assembler .attribute arch
+UNRESOLVED: gcc.target/riscv/attribute-1.c   -Os   scan-assembler .attribute arch
+UNRESOLVED: gcc.target/riscv/attribute-5.c   -O0   scan-assembler .attribute unaligned_access, 1
+UNRESOLVED: gcc.target/riscv/attribute-5.c   -O1   scan-assembler .attribute unaligned_access, 1
+UNRESOLVED: gcc.target/riscv/attribute-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler .attribute unaligned_access, 1
+UNRESOLVED: gcc.target/riscv/attribute-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler .attribute unaligned_access, 1
+UNRESOLVED: gcc.target/riscv/attribute-5.c   -O2   scan-assembler .attribute unaligned_access, 1
+UNRESOLVED: gcc.target/riscv/attribute-5.c   -O3 -g   scan-assembler .attribute unaligned_access, 1
+UNRESOLVED: gcc.target/riscv/attribute-5.c   -Os   scan-assembler .attribute unaligned_access, 1
+
+#
+# g++
+#
+FAIL: c-c++-common/analyzer/errno-1.c  -std=c++17 (test for excess errors)
+FAIL: c-c++-common/analyzer/errno-1.c  -std=c++17  (test for warnings, line 20)
+FAIL: c-c++-common/analyzer/errno-1.c  -std=c++26 (test for excess errors)
+FAIL: c-c++-common/analyzer/errno-1.c  -std=c++26  (test for warnings, line 20)
+FAIL: c-c++-common/analyzer/flex-without-call-summaries.c  -std=c++17 (test for excess errors)
+FAIL: c-c++-common/analyzer/flex-without-call-summaries.c  -std=c++26 (test for excess errors)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++17 (test for excess errors)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++17  (test for warnings, line 32)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++17  (test for warnings, line 36)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++17  (test for warnings, line 47)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++17  (test for warnings, line 57)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++26 (test for excess errors)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++26  (test for warnings, line 32)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++26  (test for warnings, line 36)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++26  (test for warnings, line 47)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++26  (test for warnings, line 57)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++98 (test for excess errors)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++98  (test for warnings, line 32)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++98  (test for warnings, line 47)
+FAIL: c-c++-common/analyzer/isatty-1.c  -std=c++98  (test for warnings, line 57)
+FAIL: c-c++-common/spec-barrier-1.c  -std=gnu++17 (test for excess errors)
+FAIL: c-c++-common/spec-barrier-1.c  -std=gnu++26 (test for excess errors)
+FAIL: c-c++-common/spec-barrier-1.c  -std=gnu++98 (test for excess errors)
+FAIL: g++.dg/contracts/contracts10.C   output pattern test
+FAIL: g++.dg/contracts/contracts19.C   output pattern test
+FAIL: g++.dg/contracts/contracts25.C   output pattern test
+FAIL: g++.dg/contracts/contracts35.C   output pattern test
+FAIL: g++.dg/contracts/contracts3.C   output pattern test
+FAIL: g++.dg/contracts/contracts5.C   output pattern test
+FAIL: g++.dg/contracts/contracts7.C   output pattern test
+FAIL: g++.dg/contracts/contracts9.C   output pattern test
+FAIL: g++.dg/contracts/contracts-access1.C   output pattern test
+FAIL: g++.dg/contracts/contracts-config1.C   output pattern test
+FAIL: g++.dg/contracts/contracts-constexpr1.C   output pattern test
+FAIL: g++.dg/contracts/contracts-deduced2.C   output pattern test
+FAIL: g++.dg/contracts/contracts-friend1.C   output pattern test
+FAIL: g++.dg/contracts/contracts-multiline1.C   output pattern test
+FAIL: g++.dg/contracts/contracts-post3.C   output pattern test
+FAIL: g++.dg/contracts/contracts-pre10.C   output pattern test
+FAIL: g++.dg/contracts/contracts-pre2a2.C  -std=c++11 output pattern test
+FAIL: g++.dg/contracts/contracts-pre2a2.C  -std=c++17 output pattern test
+FAIL: g++.dg/contracts/contracts-pre2a2.C  -std=c++26 output pattern test
+FAIL: g++.dg/contracts/contracts-pre2.C   output pattern test
+FAIL: g++.dg/contracts/contracts-pre4.C   output pattern test
+FAIL: g++.dg/contracts/contracts-pre5.C   output pattern test
+FAIL: g++.dg/contracts/contracts-pre7.C   output pattern test
+FAIL: g++.dg/contracts/contracts-pre9.C   output pattern test
+FAIL: g++.dg/contracts/contracts-redecl3.C   output pattern test
+FAIL: g++.dg/contracts/contracts-redecl4.C   output pattern test
+FAIL: g++.dg/contracts/contracts-redecl6.C   output pattern test
+FAIL: g++.dg/contracts/contracts-redecl7.C   output pattern test
+FAIL: g++.dg/contracts/contracts-tmpl-spec1.C   output pattern test
+FAIL: g++.dg/contracts/contracts-tmpl-spec2.C   output pattern test
+FAIL: g++.dg/contracts/contracts-tmpl-spec3.C   output pattern test
+FAIL: g++.dg/contracts/pr110159.C   output pattern test
+FAIL: g++.dg/contracts/pr115434.C   output pattern test
+FAIL: g++.dg/contracts/pr116490.C   output pattern test
+FAIL: g++.dg/ipa/pr63814.C  -std=gnu++17 (test for excess errors)
+FAIL: g++.dg/ipa/pr63814.C  -std=gnu++26 (test for excess errors)
+FAIL: g++.dg/ipa/pr63814.C  -std=gnu++98 (test for excess errors)
+FAIL: g++.dg/ipa/pr67056.C   (test for excess errors)
+FAIL: g++.dg/ipa/pr69239.C  -std=gnu++17 (test for excess errors)
+FAIL: g++.dg/ipa/pr69239.C  -std=gnu++26 (test for excess errors)
+FAIL: g++.dg/ipa/pr69239.C  -std=gnu++98 (test for excess errors)
+FAIL: g++.dg/lto/20081109-1 cp_lto_20081109-1_0.o-cp_lto_20081109-1_0.o link, -fPIC -flto -flto-partition=1to1
+FAIL: g++.dg/lto/20081118 cp_lto_20081118_0.o-cp_lto_20081118_1.o link, -fPIC -flto -flto-partition=1to1 -r -nostdlib
+FAIL: g++.dg/lto/20081119-1 cp_lto_20081119-1_0.o-cp_lto_20081119-1_1.o link, -fPIC -flto -flto-partition=1to1 -r -nostdlib
+FAIL: g++.dg/lto/20081120-1 cp_lto_20081120-1_0.o-cp_lto_20081120-1_1.o link, -flto -r -nostdlib
+FAIL: g++.dg/lto/20081120-2 cp_lto_20081120-2_0.o-cp_lto_20081120-2_1.o link, -flto -r -nostdlib
+FAIL: g++.dg/lto/20081123 cp_lto_20081123_0.o-cp_lto_20081123_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
+FAIL: g++.dg/lto/20081204-1 cp_lto_20081204-1_0.o-cp_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
+FAIL: g++.dg/lto/20090302 cp_lto_20090302_0.o-cp_lto_20090302_1.o link, -fPIC -flto -flto-partition=1to1 -r
+FAIL: g++.dg/lto/20090313 cp_lto_20090313_0.o-cp_lto_20090313_1.o link, -flto -flto-partition=1to1 -fPIC
+FAIL: g++.dg/lto/20091002-2 cp_lto_20091002-2_0.o-cp_lto_20091002-2_0.o link, -fPIC
+FAIL: g++.dg/lto/20091002-3 cp_lto_20091002-3_0.o-cp_lto_20091002-3_0.o link, -fPIC
+FAIL: g++.dg/lto/20091026-1 cp_lto_20091026-1_0.o-cp_lto_20091026-1_1.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/20091026-1 cp_lto_20091026-1_0.o-cp_lto_20091026-1_1.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: g++.dg/lto/20091026-1 cp_lto_20091026-1_0.o-cp_lto_20091026-1_1.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/20091026-1 cp_lto_20091026-1_0.o-cp_lto_20091026-1_1.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/20091026-1 cp_lto_20091026-1_0.o-cp_lto_20091026-1_1.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/20091026-1 cp_lto_20091026-1_0.o-cp_lto_20091026-1_1.o link, -O2 -flto -fuse-linker-plugin
+FAIL: g++.dg/lto/20100724-1 cp_lto_20100724-1_0.o-cp_lto_20100724-1_0.o link, -ftoplevel-reorder -flto -flto-partition=1to1
+FAIL: g++.dg/lto/20100724-1 cp_lto_20100724-1_0.o-cp_lto_20100724-1_0.o link, -ftoplevel-reorder -flto -flto-partition=none
+FAIL: g++.dg/lto/20101010-4 cp_lto_20101010-4_0.o-cp_lto_20101010-4_0.o link,  -std=c++0x -flto -g -r -nostdlib 
+FAIL: g++.dg/lto/20101010-4 cp_lto_20101010-4_0.o-cp_lto_20101010-4_0.o link,  -std=c++0x -flto -r -nostdlib 
+FAIL: g++.dg/lto/20101015-2 cp_lto_20101015-2_0.o-cp_lto_20101015-2_0.o link,  -flto 
+FAIL: g++.dg/lto/20101015-2 cp_lto_20101015-2_0.o-cp_lto_20101015-2_0.o link,  -g -flto 
+FAIL: g++.dg/lto/20110311-1 cp_lto_20110311-1_0.o-cp_lto_20110311-1_0.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/20110311-1 cp_lto_20110311-1_0.o-cp_lto_20110311-1_0.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: g++.dg/lto/20110311-1 cp_lto_20110311-1_0.o-cp_lto_20110311-1_0.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/20110311-1 cp_lto_20110311-1_0.o-cp_lto_20110311-1_0.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/20110311-1 cp_lto_20110311-1_0.o-cp_lto_20110311-1_0.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/20110311-1 cp_lto_20110311-1_0.o-cp_lto_20110311-1_0.o link, -O2 -flto -fuse-linker-plugin
+FAIL: g++.dg/lto/devirt-19 cp_lto_devirt-19_0.o-cp_lto_devirt-19_0.o link, -O2 -fdump-ipa-cp -fipa-cp-clone -Wno-return-type -flto -r -nostdlib
+FAIL: g++.dg/lto/devirt-22 cp_lto_devirt-22_0.o-cp_lto_devirt-22_0.o link, -O3 -fno-early-inlining -fno-ipa-sra -fdump-ipa-cp -flto -r -nostdlib
+FAIL: g++.dg/lto/devirt-30 cp_lto_devirt-30_0.o-cp_lto_devirt-30_0.o link, -O3 -fdump-ipa-devirt -flto -r -nostdlib
+FAIL: g++.dg/lto/devirt-34 cp_lto_devirt-34_0.o-cp_lto_devirt-34_0.o link, -O2 -fdump-ipa-devirt -flto -r -nostdlib
+FAIL: g++.dg/lto/pr113208 cp_lto_pr113208_0.o-cp_lto_pr113208_1.o link, -O1 -std=c++20 -flto
+FAIL: g++.dg/lto/pr45679-1 cp_lto_pr45679-1_0.o-cp_lto_pr45679-1_1.o link, -O3 -Wno-multichar -Wno-return-type 
+FAIL: g++.dg/lto/pr45679-2 cp_lto_pr45679-2_0.o-cp_lto_pr45679-2_1.o link, -O3 -Wno-multichar -Wno-return-type
+FAIL: g++.dg/lto/pr48042 cp_lto_pr48042_0.o-cp_lto_pr48042_0.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/pr48042 cp_lto_pr48042_0.o-cp_lto_pr48042_0.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: g++.dg/lto/pr48042 cp_lto_pr48042_0.o-cp_lto_pr48042_0.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/pr48042 cp_lto_pr48042_0.o-cp_lto_pr48042_0.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/pr48042 cp_lto_pr48042_0.o-cp_lto_pr48042_0.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/pr48042 cp_lto_pr48042_0.o-cp_lto_pr48042_0.o link, -O2 -flto -fuse-linker-plugin
+FAIL: g++.dg/lto/pr48354-1 cp_lto_pr48354-1_0.o-cp_lto_pr48354-1_0.o link,  -g -flto 
+FAIL: g++.dg/lto/pr54625-1 cp_lto_pr54625-1_0.o-cp_lto_pr54625-1_1.o link,  -O0 -flto -w -std=gnu17 
+FAIL: g++.dg/lto/pr54625-1 cp_lto_pr54625-1_0.o-cp_lto_pr54625-1_1.o link,  -O2 -flto -w -std=gnu17 
+FAIL: g++.dg/lto/pr54625-2 cp_lto_pr54625-2_0.o-cp_lto_pr54625-2_1.o link,  -O0 -flto -w -std=gnu17 
+FAIL: g++.dg/lto/pr54625-2 cp_lto_pr54625-2_0.o-cp_lto_pr54625-2_1.o link,  -O2 -flto -w -std=gnu17 
+FAIL: g++.dg/lto/pr60567 cp_lto_pr60567_0.o-cp_lto_pr60567_0.o link,  -flto -fno-use-linker-plugin 
+FAIL: g++.dg/lto/pr62026 cp_lto_pr62026_0.o-cp_lto_pr62026_0.o link, -flto -O3 -r -Wno-return-type
+FAIL: g++.dg/lto/pr65475b cp_lto_pr65475b_0.o-cp_lto_pr65475b_1.o link, -O2
+FAIL: g++.dg/lto/pr65475b cp_lto_pr65475b_0.o-cp_lto_pr65475b_1.o link, -Wno-odr
+FAIL: g++.dg/lto/pr65475c cp_lto_pr65475c_0.o-cp_lto_pr65475c_1.o link, -O2 -w -Wno-return-type
+FAIL: g++.dg/lto/pr65475 cp_lto_pr65475_0.o-cp_lto_pr65475_1.o link, -O2
+FAIL: g++.dg/lto/pr65475 cp_lto_pr65475_0.o-cp_lto_pr65475_1.o link, -Wno-odr
+FAIL: g++.dg/lto/pr68811 cp_lto_pr68811_0.o-cp_lto_pr68811_1.o link,  -O2 -w 
+FAIL: g++.dg/lto/pr68811 cp_lto_pr68811_0.o-cp_lto_pr68811_1.o link,  -w 
+FAIL: g++.dg/lto/pr87089 cp_lto_pr87089_0.o-cp_lto_pr87089_1.o link, -O0 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/pr87089 cp_lto_pr87089_0.o-cp_lto_pr87089_1.o link, -O0 -flto -flto-partition=none -fuse-linker-plugin
+FAIL: g++.dg/lto/pr87089 cp_lto_pr87089_0.o-cp_lto_pr87089_1.o link, -O0 -flto -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/pr87089 cp_lto_pr87089_0.o-cp_lto_pr87089_1.o link, -O2 -flto -flto-partition=1to1 -fno-use-linker-plugin 
+FAIL: g++.dg/lto/pr87089 cp_lto_pr87089_0.o-cp_lto_pr87089_1.o link, -O2 -flto -flto-partition=none -fuse-linker-plugin -fno-fat-lto-objects 
+FAIL: g++.dg/lto/pr87089 cp_lto_pr87089_0.o-cp_lto_pr87089_1.o link, -O2 -flto -fuse-linker-plugin
+FAIL: g++.dg/lto/pr89335 cp_lto_pr89335_0.o-cp_lto_pr89335_0.o link, -O2 -flto -Wsuggest-final-methods
+FAIL: g++.dg/modules/global-3 -std=c++17 link
+FAIL: g++.dg/modules/global-3 -std=c++2a link
+FAIL: g++.dg/modules/global-3 -std=c++2b link
+FAIL: g++.dg/modules/hello-1 -std=c++17 link
+FAIL: g++.dg/modules/hello-1 -std=c++2a link
+FAIL: g++.dg/modules/hello-1 -std=c++2b link
+FAIL: g++.dg/modules/hello-2 -std=c++17 link
+FAIL: g++.dg/modules/hello-2 -std=c++2a link
+FAIL: g++.dg/modules/hello-2 -std=c++2b link
+FAIL: g++.dg/modules/iostream-1 -std=c++17 link
+FAIL: g++.dg/modules/iostream-1 -std=c++2a link
+FAIL: g++.dg/modules/iostream-1 -std=c++2b link
+FAIL: g++.dg/torture/pr71571.C   -O0  (test for excess errors)
+FAIL: g++.dg/torture/pr71571.C   -O1  (test for excess errors)
+FAIL: g++.dg/torture/pr71571.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+FAIL: g++.dg/torture/pr71571.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+FAIL: g++.dg/torture/pr71571.C   -O2  (test for excess errors)
+FAIL: g++.dg/torture/pr71571.C   -O3 -g  (test for excess errors)
+FAIL: g++.dg/torture/pr71571.C   -Os  (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-alloca-1.C   -O0 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-alloca-1.C   -O1 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-alloca-1.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-alloca-1.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-alloca-1.C   -O2 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-alloca-1.C   -O3 -g -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-alloca-1.C   -Os -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-global-1.C   -O0 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-global-1.C   -O1 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-global-1.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-global-1.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-global-1.C   -O2 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-global-1.C   -O3 -g -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-global-1.C   -Os -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-1.C   -O0 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-1.C   -O1 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-1.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-1.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-1.C   -O2 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-1.C   -O3 -g -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-1.C   -Os -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-2.C   -O0 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-2.C   -O1 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-2.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-2.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-2.C   -O2 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-2.C   -O3 -g -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-inline-2.C   -Os -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-1.C   -O0 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-1.C   -O1 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-1.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-1.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-1.C   -O2 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-1.C   -O3 -g -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-1.C   -Os -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-2.C   -O0 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-2.C   -O1 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-2.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-2.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-2.C   -O2 -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-2.C   -O3 -g -fpic (test for excess errors)
+FAIL: g++.dg/torture/stackalign/eh-vararg-2.C   -Os -fpic (test for excess errors)
+FAIL: g++.old-deja/g++.jason/thunk2.C  -std=gnu++17 (test for excess errors)
+FAIL: g++.old-deja/g++.jason/thunk2.C  -std=gnu++26 (test for excess errors)
+FAIL: g++.old-deja/g++.jason/thunk2.C  -std=gnu++98 (test for excess errors)
+FAIL: g++.target/riscv/redundant-bitmap-2.C scan-assembler-not bclr\t
+FAIL: g++.target/riscv/redundant-bitmap-2.C scan-assembler-times bset\t 1
+UNRESOLVED: g++.dg/modules/global-3 -std=c++17 execute
+UNRESOLVED: g++.dg/modules/global-3 -std=c++2a execute
+UNRESOLVED: g++.dg/modules/global-3 -std=c++2b execute
+UNRESOLVED: g++.dg/modules/hello-1 -std=c++17 execute
+UNRESOLVED: g++.dg/modules/hello-1 -std=c++2a execute
+UNRESOLVED: g++.dg/modules/hello-1 -std=c++2b execute
+UNRESOLVED: g++.dg/modules/hello-2 -std=c++17 execute
+UNRESOLVED: g++.dg/modules/hello-2 -std=c++2a execute
+UNRESOLVED: g++.dg/modules/hello-2 -std=c++2b execute
+UNRESOLVED: g++.dg/modules/iostream-1 -std=c++17 execute
+UNRESOLVED: g++.dg/modules/iostream-1 -std=c++2a execute
+UNRESOLVED: g++.dg/modules/iostream-1 -std=c++2b execute

--- a/test/allowlist/gcc/picolibc.log
+++ b/test/allowlist/gcc/picolibc.log
@@ -177,11 +177,6 @@ FAIL: gcc.target/riscv/cpymemsi-2.c   -O2 -flto -fno-use-linker-plugin -flto-par
 FAIL: gcc.target/riscv/cpymemsi-2.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   scan-assembler-times \t(call|tail)\tmemcpy 6
 FAIL: gcc.target/riscv/cpymemsi-2.c   -O2   scan-assembler-times \t(call|tail)\tmemcpy 6
 FAIL: gcc.target/riscv/cpymemsi-2.c   -O3 -g   scan-assembler-times \t(call|tail)\tmemcpy 6
-FAIL: gcc.target/riscv/interrupt-misaligned.c   -O0   check-function-bodies interrupt
-FAIL: gcc.target/riscv/interrupt-misaligned.c   -O1   check-function-bodies interrupt
-FAIL: gcc.target/riscv/interrupt-misaligned.c   -O2   check-function-bodies interrupt
-FAIL: gcc.target/riscv/interrupt-misaligned.c   -O3 -g   check-function-bodies interrupt
-FAIL: gcc.target/riscv/interrupt-misaligned.c   -Os   check-function-bodies interrupt
 FAIL: gcc.target/riscv/round.c   -O0  (test for excess errors)
 FAIL: gcc.target/riscv/round.c   -O1  (test for excess errors)
 FAIL: gcc.target/riscv/round.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
@@ -230,21 +225,9 @@ FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O
 FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfrsub\\.vf 6
 FAIL: gcc.target/riscv/rvv/autovec/binop/vsub-rv32gcv-nofm.c -ftree-vectorize -O3 -mrvv-max-lmul=m8  scan-assembler-times \\tvfsub\\.vv 3
 FAIL: gcc.target/riscv/rvv/autovec/bug-3.c -O3 -ftree-vectorize  check-function-bodies foo
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-10.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1di_RET1_ARG3
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-8.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2si_RET1_ARG2
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v1df_RET1_ARG3
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v2sf_RET1_ARG2
-FAIL: gcc.target/riscv/rvv/autovec/vls/calling-convention-9.c -O3 -ftree-vectorize -mrvv-vector-bits=scalable  check-function-bodies v4sf_RET1_ARG2
 FAIL: gcc.target/riscv/rvv/base/cpymem-strategy-2.c scan-assembler-times call\\tmemcpy 1
 FAIL: gcc.target/riscv/rvv/base/setmem-1.c check-function-bodies f2
 FAIL: gcc.target/riscv/rvv/base/setmem-1.c check-function-bodies f3
-FAIL: gcc.target/riscv/rvv/base/spill-10.c check-function-bodies stach_check_alloca_1
-FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_1
-FAIL: gcc.target/riscv/rvv/base/spill-8.c check-function-bodies stach_check_alloca_2
-FAIL: gcc.target/riscv/rvv/base/spill-9.c check-function-bodies stach_check_alloca_1
 FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O0   scan-assembler-times vsetivli\\tzero,\\s*1 2
 FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O1   scan-assembler-times vsetivli\\tzero,\\s*1 2
 FAIL: gcc.target/riscv/rvv/vsetvl/avl_prop-2.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none   scan-assembler-times vsetivli\\tzero,\\s*1 2


### PR DESCRIPTION
Using a single allowlist file for all `-mtune` tests can hide real issues. A failure that is known for one `mtune` but not for another may be incorrectly removed from the “unknown failures” report. To prevent this, the testsuite filter needs to support a separate allowlist per `mtune`.

To support this, the `-mtune` flags are now passed through the target board options (Same setup on Jenkins):
[https://github.com/foss-for-synopsys-dwc-arc-processors/arcv-gnu-toolchain/pull/9/files#diff-b48650cabc0f502b52865f525765f2d688198f06e0ffb5456c76fabab7f2bfb2R139](https://github.com/foss-for-synopsys-dwc-arc-processors/arcv-gnu-toolchain/pull/9/files#diff-b48650cabc0f502b52865f525765f2d688198f06e0ffb5456c76fabab7f2bfb2R139)

By default, the tests run with the `mtune` configured in the toolchain. It is also possible to set `MTUNE_FOR_TARGET` to run the tests with a different `mtune` than the one used to configure the toolchain.
