### PR TITLE
nsim: Remove old Meson hack for exe_wrapper

### DIFF
--- a/scripts/generate_picolibc_cross_file
+++ b/scripts/generate_picolibc_cross_file
@@ -70,12 +70,12 @@ def main(argv):
 
     if options.simulator == "qemu":
         content += (
-            r"""exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-riscv "$@"', 'run-riscv']"""
+            r"""exe_wrapper = ['env', 'run-riscv']"""
             + "\n"
         )
     elif options.simulator == "nsim":
         content += (
-            r"""exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-riscv-nsim "$@"', 'run-riscv-nsim']"""
+            r"""exe_wrapper = ['env', 'run-riscv-nsim']"""
             + "\n"
         )
     else:


### PR DESCRIPTION
Old Meson used this hack for running testing using a wrapper. It was removed from Picolibc thus it's useless now. Just use a plain wrapper command like it's done in Picolibc examples.