### PR TITLE
Add --with-multilib-list GCC option support.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -72,12 +72,15 @@ export PATH AWK SED
 
 MULTILIB_FLAGS := @multilib_flags@
 MULTILIB_GEN := @multilib_gen@
+MULTILIB_LIST_FLAGS := @multilib_list_flags@
 ifeq ($(MULTILIB_GEN),)
 NEWLIB_MULTILIB_NAMES := @newlib_multilib_names@
 GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS)
+GCC_MULTILIB_LIST_FLAGS := $(MULTILIB_LIST_FLAGS)
 else
 NEWLIB_MULTILIB_NAMES := $(shell echo "$(MULTILIB_GEN)" | $(SED) 's/;/\n/g' | $(SED) '/^$$/d' | $(AWK) '{split($$0,a,"-"); printf "%s-%s", (NR==1?a[1]:" "a[1]),a[2]}')
 GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS) --with-multilib-generator="$(MULTILIB_GEN)"
+GCC_MULTILIB_LIST_FLAGS := $(MULTILIB_LIST_FLAGS)
 endif
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
@@ -751,6 +754,7 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binuti
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(GCC_MULTILIB_FLAGS) \
+		$(GCC_MULTILIB_LIST_FLAGS) \
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
@@ -867,6 +871,7 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(GCC_MULTILIB_FLAGS) \
+		$(GCC_MULTILIB_LIST_FLAGS) \
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
@@ -954,6 +959,7 @@ stamps/build-gcc-picolibc-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binu
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(GCC_MULTILIB_FLAGS) \
+		$(GCC_MULTILIB_LIST_FLAGS) \
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
@@ -1085,6 +1091,7 @@ stamps/build-gcc-picolibc-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-pico
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(GCC_MULTILIB_FLAGS) \
+		$(GCC_MULTILIB_LIST_FLAGS) \
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \

--- a/configure
+++ b/configure
@@ -641,6 +641,7 @@ host_cxxflags
 host_cflags
 target_cxxflags
 target_cflags
+multilib_list_flags
 cmodel
 gcc_checking
 musl_multilib_names
@@ -738,6 +739,7 @@ with_multilib_generator
 with_extra_multilib_test
 enable_gcc_checking
 with_cmodel
+with_multilib_list
 with_target_cflags
 with_target_cxxflags
 with_host_cflags
@@ -1443,6 +1445,9 @@ Optional Packages:
                           --with-extra-multilib-test="rv64gcv-lp64;rv64gcv_zba-lp64"
   --with-cmodel           Select the code model to use when building libc and
                           libgcc [--with-cmodel=medlow]
+  --with-multilib-list=LIST
+                          select specific multilibs to build (e.g., reduced,
+                          release)
   --with-target-cflags    Add extra target flags for C for library code
   --with-target-cxxflags  Add extra target flags for C++ for library code
   --with-host-cflags      Add extra flags for C for host Binutils, GDB and GCC
@@ -4293,6 +4298,24 @@ then :
 
 else $as_nop
   cmodel=-mcmodel=medlow
+
+fi
+
+
+# Check whether --with-multilib_list was given.
+if test ${with_multilib_list+y}
+then :
+  withval=$with_multilib_list;
+else $as_nop
+  with_multilib_list=default
+
+fi
+
+if test "x$with_multilib_list" != xdefault
+then :
+  multilib_list_flags=--with-multilib-list=$with_multilib_list
+
+else $as_nop
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,16 @@ AS_IF([test "x$with_cmodel" != x],
 	[AC_SUBST(cmodel, -mcmodel=$with_cmodel)],
 	[AC_SUBST(cmodel, -mcmodel=medlow)])
 
+AC_ARG_WITH(multilib_list,
+	[AS_HELP_STRING([--with-multilib-list=LIST],
+		[select specific multilibs to build (e.g., reduced, release)])],
+	[],
+	[with_multilib_list=default]
+	)
+AS_IF([test "x$with_multilib_list" != xdefault],
+	[AC_SUBST(multilib_list_flags,--with-multilib-list=$with_multilib_list)],
+	[AC_SUBST(multilib_list_flags,)])
+
 AC_ARG_WITH(target_cflags,
 	[AS_HELP_STRING([--with-target-cflags],
 		[Add extra target flags for C for library code])],


### PR DESCRIPTION
Add support for the --with-multilib-list configure option to select specific multilib configurations when building the toolchain.

The option if forwarded to both GCC stages for both newlib and picolibc targets.

Accepted values:
  reduced: build a reduced multilib set.
  release: build the full multilib set.
  (You can check gcc/gcc/config.gcc for other options.)

Using a reduced set speeds up development and testing builds by avoiding unnecesary multilib variants.

Example:
  ./configure --with-multilib-list=reduced
  ./configure --with-multilib-list=release # (currently default)