### PR TITLE
Rework targets for Picolibc toolchains

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -220,8 +220,8 @@ check-gcc-picolibc-nano: stamps/check-gcc-picolibc-nano
 .PHONY: check-libc-newlib check-libc-newlib-nano
 check-libc-newlib: stamps/check-libc-newlib
 check-libc-newlib-nano: stamps/check-libc-newlib-nano
-.PHONY: check-libc-picolibc-perf check-libc-picolibc-nano
-check-libc-picolibc-perf: stamps/check-libc-picolibc-perf
+.PHONY: check-libc-picolibc check-libc-picolibc-nano
+check-libc-picolibc: stamps/check-libc-picolibc
 check-libc-picolibc-nano: stamps/check-libc-picolibc-nano
 .PHONY: check-glibc-linux
 check-glibc-linux: $(addprefix stamps/check-glibc-linux-,$(GLIBC_MULTILIB_NAMES))
@@ -968,7 +968,6 @@ stamps/build-gcc-picolibc-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binu
 	mkdir -p $(dir $@) && touch $@
 
 PICOLIBC_COMMON_CONFIGURE_OPTIONS := \
-	--cross-file cross-$(NEWLIB_TUPLE).txt \
 	-Dincludedir=include \
 	-Dsystem-libc=true \
 	-Dposix-console=true \
@@ -978,7 +977,7 @@ PICOLIBC_COMMON_CONFIGURE_OPTIONS := \
 	-Ddebug=true \
 	-Dwerror=true
 
-PICOLIBC_PERF_CONFIGURE_OPTIONS := \
+PICOLIBC_CONFIGURE_OPTIONS := \
 	-Doptimization=3 \
 	-Dio-c99-formats=true \
 	-Dio-long-long=true \
@@ -1012,56 +1011,34 @@ define PICOLIBC_OBSOLETE_MATH_BLOCK
 endef
 export PICOLIBC_OBSOLETE_MATH_BLOCK
 
-PICOLIBC_RELEASE_LAYOUT_SETTINGS := \
-	--flash-addr "0x00000000" \
-	--flash-size "128K" \
-	--ram-addr "0x40000000" \
-	--ram-size "128K"
-
-PICOLIBC_NSIM_LAYOUT_SETTINGS := \
-	--flash-addr "0x00000000" \
-	--flash-size "32M" \
-	--ram-addr "0x40000000" \
-	--ram-size "32M"
-
-PICOLIBC_QEMU_LAYOUT_SETTINGS := \
+PICOLIBC_LAYOUT_SETTINGS := \
 	--flash-addr "0x80000000" \
 	--flash-size "32M" \
 	--ram-addr "0x82000000" \
 	--ram-size "32M"
 
-ifeq ($(SIM),nsim)
-PICOLIBC_TEST_LAYOUT_SETTINGS := $(PICOLIBC_NSIM_LAYOUT_SETTINGS)
-endif
-
-ifeq ($(SIM),qemu)
-PICOLIBC_TEST_LAYOUT_SETTINGS := $(PICOLIBC_QEMU_LAYOUT_SETTINGS)
-endif
-
-stamps/configure-picolibc-perf: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/build-gcc-picolibc-stage1
-	rm -rf $@ stamps/build-picolibc-perf build-picolibc-perf
-	mkdir build-picolibc-perf
-	cd build-picolibc-perf && $(srcdir)/scripts/generate_picolibc_cross_file \
+stamps/build-picolibc: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/build-gcc-picolibc-stage1
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	$(srcdir)/scripts/generate_picolibc_cross_file \
 		--triplet $(NEWLIB_TUPLE) \
-		$(PICOLIBC_RELEASE_LAYOUT_SETTINGS) \
+		$(PICOLIBC_LAYOUT_SETTINGS) \
 		--cflags "$(CFLAGS_FOR_TARGET)" \
 		--simulator nsim \
-		> cross-$(NEWLIB_TUPLE).txt
-	cd build-picolibc-perf && meson setup . $(PICOLIBC_SRCDIR) \
+		> $(notdir $@)/cross-$(NEWLIB_TUPLE).txt
+	meson setup $(notdir $@) $(PICOLIBC_SRCDIR) \
+		--cross-file $(notdir $@)/cross-$(NEWLIB_TUPLE).txt \
 		-Dprefix=$(INSTALL_DIR)/$(NEWLIB_TUPLE) \
 		-Dlibdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
 		-Dspecsdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
-		$(PICOLIBC_PERF_CONFIGURE_OPTIONS)
-	cd build-picolibc-perf && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
-	mkdir -p $(dir $@) && touch $@
-
-stamps/build-picolibc-perf: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/configure-picolibc-perf
-	ninja -C $(notdir $@)
-	ninja -C $(notdir $@) install
+		$(PICOLIBC_CONFIGURE_OPTIONS)
+	echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> $(notdir $@)/picolibc.h
+	meson compile -C $(notdir $@)
+	meson install -C $(notdir $@)
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-gcc-picolibc-stage2: ENABLED_LANGUAGES?="c,c++"
-stamps/build-gcc-picolibc-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-picolibc-perf
+stamps/build-gcc-picolibc-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-picolibc
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -1098,26 +1075,24 @@ stamps/build-gcc-picolibc-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-pico
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/configure-picolibc-nano: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/build-gcc-picolibc-stage2
-	rm -rf $@ stamps/build-picolibc-nano build-picolibc-nano
-	mkdir build-picolibc-nano
-	cd build-picolibc-nano && $(srcdir)/scripts/generate_picolibc_cross_file \
+stamps/build-picolibc-nano: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/build-gcc-picolibc-stage2
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	$(srcdir)/scripts/generate_picolibc_cross_file \
 		--triplet $(NEWLIB_TUPLE) \
-		$(PICOLIBC_RELEASE_LAYOUT_SETTINGS) \
-		--cflags "$(CFLAGS_FOR_TARGET) -msave-restore" \
+		$(PICOLIBC_LAYOUT_SETTINGS) \
+		--cflags "$(CFLAGS_FOR_TARGET) -Os" \
 		--simulator nsim \
-		> cross-$(NEWLIB_TUPLE).txt
-	cd build-picolibc-nano && meson setup . $(PICOLIBC_SRCDIR) \
+		> $(notdir $@)/cross-$(NEWLIB_TUPLE).txt
+	meson setup $(notdir $@) $(PICOLIBC_SRCDIR) \
+		--cross-file $(notdir $@)/cross-$(NEWLIB_TUPLE).txt \
 		-Dprefix=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE) \
 		-Dlibdir=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE)/lib \
 		-Dspecsdir=none \
 		$(PICOLIBC_NANO_CONFIGURE_OPTIONS)
-	cd build-picolibc-nano && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
-	mkdir -p $(dir $@) && touch $@
-
-stamps/build-picolibc-nano: $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT) stamps/configure-picolibc-nano
-	ninja -C $(notdir $@)
-	ninja -C $(notdir $@) install
+	echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> $(notdir $@)/picolibc.h
+	meson compile -C $(notdir $@)
+	meson install -C $(notdir $@)
 	$(srcdir)/scripts/generate_picolibc_nano_specs \
 		--triplet $(NEWLIB_TUPLE) \
 		--nano-dir-name picolibc-nano \
@@ -1160,60 +1135,6 @@ stamps/build-gcc-picolibc-stage2-nano: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build
 	$(MAKE) -C $(notdir $@) all-target-libgcc all-target-libstdc++-v3
 	$(MAKE) -C $(notdir $@) install-target-libgcc install-target-libstdc++-v3
 	mkdir -p $(dir $@) && touch $@
-
-stamps/configure-picolibc-perf-test: stamps/build-gcc-picolibc-stage2 $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT)
-	rm -rf $@ stamps/build-picolibc-perf-test build-picolibc-perf-test
-	mkdir build-picolibc-perf-test
-	cd build-picolibc-perf-test && $(srcdir)/scripts/generate_picolibc_cross_file \
-		--triplet $(NEWLIB_TUPLE) \
-		$(PICOLIBC_TEST_LAYOUT_SETTINGS) \
-		--cflags "$(CFLAGS_FOR_TARGET)" \
-		--simulator "$(SIM)" \
-		> cross-$(NEWLIB_TUPLE).txt
-	cd build-picolibc-perf-test && meson setup . $(PICOLIBC_SRCDIR) \
-		-Dprefix=$(INSTALL_DIR)/$(NEWLIB_TUPLE) \
-		-Dlibdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
-		-Dspecsdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
-		-Dtests=true \
-		-Dtest-machine=$(SIM) \
-		$(PICOLIBC_PERF_CONFIGURE_OPTIONS)
-	cd build-picolibc-perf-test && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
-	mkdir -p $(dir $@) && touch $@
-
-stamps/build-picolibc-perf-test: stamps/configure-picolibc-perf-test
-	ninja -C $(notdir $@)
-	mkdir -p $(dir $@) && touch $@
-
-stamps/check-libc-picolibc-perf: stamps/build-picolibc-perf-test $(SIM_STAMP)
-	meson test -C build-picolibc-perf-test || true
-	date > $@
-
-stamps/configure-picolibc-nano-test: stamps/build-gcc-picolibc-stage2 $(PICOLIBC_SRCDIR) $(PICOLIBC_SRC_GIT)
-	rm -rf $@ stamps/build-picolibc-nano-test build-picolibc-nano-test
-	mkdir build-picolibc-nano-test
-	cd build-picolibc-nano-test && $(srcdir)/scripts/generate_picolibc_cross_file \
-		--triplet $(NEWLIB_TUPLE) \
-		$(PICOLIBC_TEST_LAYOUT_SETTINGS) \
-		--cflags "$(CFLAGS_FOR_TARGET)" \
-		--simulator "$(SIM)" \
-		> cross-$(NEWLIB_TUPLE).txt
-	cd build-picolibc-nano-test && meson setup . $(PICOLIBC_SRCDIR) \
-		-Dprefix=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE) \
-		-Dlibdir=$(INSTALL_DIR)/picolibc-nano/$(NEWLIB_TUPLE)/lib \
-		-Dspecsdir=none \
-		-Dtests=true \
-		-Dtest-machine=$(SIM) \
-		$(PICOLIBC_NANO_CONFIGURE_OPTIONS)
-	cd build-picolibc-nano-test && echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> picolibc.h
-	mkdir -p $(dir $@) && touch $@
-
-stamps/build-picolibc-nano-test: stamps/configure-picolibc-nano-test
-	ninja -C $(notdir $@)
-	mkdir -p $(dir $@) && touch $@
-
-stamps/check-libc-picolibc-nano: stamps/build-picolibc-nano-test $(SIM_STAMP)
-	meson test -C build-picolibc-nano-test || true
-	date > $@
 
 #
 # MUSL
@@ -1699,6 +1620,40 @@ stamps/check-libc-newlib: stamps/build-gcc-newlib-stage2 $(SIM_STAMP) stamps/bui
 
 stamps/check-libc-newlib-nano: stamps/build-gcc-newlib-stage2 $(SIM_STAMP) stamps/build-dejagnu
 	$(SIM_PREPARE_NANO) $(MAKE) -C build-newlib-nano check-target-newlib "RUNTESTFLAGS=$(RUNTESTFLAGS) --target_board='$(NEWLIB_TARGET_BOARDS)'"
+	mkdir -p $(dir $@)
+	date > $@
+
+stamps/check-libc-picolibc: stamps/build-gcc-picolibc-stage2 $(SIM_STAMP)
+	rm -rf build-picolibc-test
+	mkdir build-picolibc-test
+	meson setup build-picolibc-test $(PICOLIBC_SRCDIR) \
+		--cross-file build-picolibc/cross-$(NEWLIB_TUPLE).txt \
+		-Dprefix=$(INSTALL_DIR)/$(NEWLIB_TUPLE) \
+		-Dlibdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		-Dspecsdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		$(PICOLIBC_CONFIGURE_OPTIONS) \
+		-Dtests=true \
+		-Dtest-machine=$(SIM)
+	echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> build-picolibc-test/picolibc.h
+	meson compile -C build-picolibc-test
+	meson test -j 4 -t 5 -C build-picolibc-test || true
+	mkdir -p $(dir $@)
+	date > $@
+
+stamps/check-libc-picolibc-nano: stamps/build-gcc-picolibc-stage2-nano $(SIM_STAMP)
+	rm -rf build-picolibc-nano-test
+	mkdir build-picolibc-nano-test
+	meson setup build-picolibc-nano-test $(PICOLIBC_SRCDIR) \
+		--cross-file build-picolibc-nano/cross-$(NEWLIB_TUPLE).txt \
+		-Dprefix=$(INSTALL_DIR)/$(NEWLIB_TUPLE) \
+		-Dlibdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		-Dspecsdir=$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib \
+		$(PICOLIBC_NANO_CONFIGURE_OPTIONS) \
+		-Dtests=true \
+		-Dtest-machine=$(SIM)
+	echo "$$PICOLIBC_OBSOLETE_MATH_BLOCK" >> build-picolibc-nano-test/picolibc.h
+	meson compile -C build-picolibc-nano-test
+	meson test -j 4 -t 5 -C build-picolibc-nano-test || true
 	mkdir -p $(dir $@)
 	date > $@
 

--- a/scripts/wrapper/nsim/riscv32-unknown-elf-run
+++ b/scripts/wrapper/nsim/riscv32-unknown-elf-run
@@ -5,7 +5,7 @@ isa="$(march-to-cpu-opt --elf-file-path $1 --print-nsim-isa)"
 
 nsimdrv \
     -p nsim_isa_family=${family} \
-    -p nsim_isa_ext=${isa} \
+    -p nsim_isa_ext=${isa}.zicsr \
     -p nsim_semihosting=1 \
     -p enable_exceptions=0 \
     "$@"


### PR DESCRIPTION
1. Remove -perf postfix for a regular Picolibc build.
2. Increase timeout limit for tests and set a fixed
   number of threads for tests.
3. Use a single memory layout for all builds.
4. Simplify all targets.