### PR TITLE
allowlist: Add gcc.dg/pr44028.c to picolibc arc-v-rmx-500-series allo…

### DIFF
--- a/test/allowlist/gcc/picolibc.arc-v-rmx-500-series.log
+++ b/test/allowlist/gcc/picolibc.arc-v-rmx-500-series.log
@@ -7,6 +7,8 @@
 #
 ERROR: /SCRATCH/arcjenkins2-1/slaves/us01-odc-custom-arcoss1/workspace/arcoss_verification/arc_gnu_toolchain_verification/baremetal_tests-51/sources/src/gcc/gcc/testsuite/gcc.dg/lto/20081212-1_0.c: error executing dg-final: expected boolean value but got ""
 UNRESOLVED: /SCRATCH/arcjenkins2-1/slaves/us01-odc-custom-arcoss1/workspace/arcoss_verification/arc_gnu_toolchain_verification/baremetal_tests-51/sources/src/gcc/gcc/testsuite/gcc.dg/lto/20081212-1_0.c: error executing dg-final: expected boolean value but got ""
+# '-fcompare-debug' failure
+FAIL: gcc.dg/pr44028.c (test for excess errors)
 
 #
 # g++


### PR DESCRIPTION
…wlist.

The test fails with '-fcompare-debug' failure (excess errors).